### PR TITLE
exclude tests too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email="liuhanjin-sc@g.ecc.u-tokyo.ac.jp",
     license="BSD 3-Clause",
     download_url="https://github.com/hanjinliu/magic-class",
-    packages=find_packages(exclude=["docs", "examples", "rst"]),
+    packages=find_packages(exclude=["docs", "examples", "rst", "tests", "tests.*"]),
     package_data={"magicclass": ["**/*.pyi", "*.pyi"]},
     install_requires=[
           "magicgui>=0.3.4",


### PR DESCRIPTION
A top-level tests package is usually a bad idea since it can be clobbered with other (mispackaged) distributions. If you want to distribute tests, they should be included within the main namespace of the package.

I am patching this as part of the review for the https://github.com/conda-forge/staged-recipes/pull/17817.

Thanks!