### PR TITLE
Always record method calls

### DIFF
--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.23.dev1"
+__version__ = "0.6.0.dev0"
 
 from .core import (
     magicclass,

--- a/magicclass/core.py
+++ b/magicclass/core.py
@@ -23,7 +23,14 @@ from .gui.class_gui import (
     ToolBoxClassGui,
     ListClassGui,
 )
-from .gui._base import PopUpMode, ErrorMode, defaults, MagicTemplate, check_override
+from .gui._base import (
+    PopUpMode,
+    ErrorMode,
+    defaults,
+    MagicTemplate,
+    check_override,
+    convert_attributes,
+)
 from .gui import ContextMenuGui, MenuGui, ToolBarGui
 from ._app import get_app
 from .types import WidgetType
@@ -146,8 +153,9 @@ def magicclass(
         mod = cls.__module__
         qualname = cls.__qualname__
 
+        new_attrs = convert_attributes(cls)
         oldclass = type(cls.__name__ + _BASE_CLASS_SUFFIX, (cls,), {})
-        newclass = type(cls.__name__, (class_gui, oldclass), {})
+        newclass = type(cls.__name__, (class_gui, oldclass), new_attrs)
 
         newclass.__signature__ = sig
         newclass.__doc__ = doc
@@ -160,9 +168,8 @@ def magicclass(
 
         @functools_wraps(oldclass.__init__)
         def __init__(self: MagicTemplate, *args, **kwargs):
-            app = (
-                get_app()
-            )  # Without "app = " Jupyter freezes after closing the window!
+            # Without "app = " Jupyter freezes after closing the window!
+            app = get_app()
 
             class_gui.__init__(
                 self,
@@ -401,8 +408,9 @@ def _call_magicmenu(
         mod = cls.__module__
         qualname = cls.__qualname__
 
+        new_attrs = convert_attributes(cls)
         oldclass = type(cls.__name__ + _BASE_CLASS_SUFFIX, (cls,), {})
-        newclass = type(cls.__name__, (menugui_class, oldclass), {})
+        newclass = type(cls.__name__, (menugui_class, oldclass), new_attrs)
 
         newclass.__signature__ = sig
         newclass.__doc__ = doc
@@ -411,9 +419,8 @@ def _call_magicmenu(
 
         @functools_wraps(oldclass.__init__)
         def __init__(self: MagicTemplate, *args, **kwargs):
-            app = (
-                get_app()
-            )  # Without "app = " Jupyter freezes after closing the window!
+            # Without "app = " Jupyter freezes after closing the window!
+            app = get_app()
 
             menugui_class.__init__(
                 self,

--- a/magicclass/core.py
+++ b/magicclass/core.py
@@ -153,7 +153,7 @@ def magicclass(
         mod = cls.__module__
         qualname = cls.__qualname__
 
-        new_attrs = convert_attributes(cls)
+        new_attrs = convert_attributes(cls, hide=class_gui.__mro__)
         oldclass = type(cls.__name__ + _BASE_CLASS_SUFFIX, (cls,), {})
         newclass = type(cls.__name__, (class_gui, oldclass), new_attrs)
 
@@ -408,7 +408,7 @@ def _call_magicmenu(
         mod = cls.__module__
         qualname = cls.__qualname__
 
-        new_attrs = convert_attributes(cls)
+        new_attrs = convert_attributes(cls, hide=menugui_class.__mro__)
         oldclass = type(cls.__name__ + _BASE_CLASS_SUFFIX, (cls,), {})
         newclass = type(cls.__name__, (menugui_class, oldclass), new_attrs)
 

--- a/magicclass/gui/_base.py
+++ b/magicclass/gui/_base.py
@@ -10,6 +10,7 @@ from typing import (
     overload,
     MutableSequence,
 )
+from types import MethodType
 from typing_extensions import _AnnotatedAlias
 import inspect
 import warnings
@@ -506,7 +507,7 @@ class MagicTemplate:
         """
         raise NotImplementedError()
 
-    def _create_widget_from_method(self, obj: Callable):
+    def _create_widget_from_method(self, obj: MethodType):
         """Convert instance methods into GUI objects, such as push buttons or actions."""
         text = obj.__name__.replace("_", " ")
         widget = self._component_class(name=obj.__name__, text=text, gui_only=True)
@@ -522,24 +523,12 @@ class MagicTemplate:
             raise ValueError(self._error_mode)
 
         # Wrap function to block macro recording.
-        _inner_func = wrapper(obj, parent=self)
-        if _need_record(obj):
-
-            @functools_wraps(obj)
-            def func(*args, **kwargs):
-                with self.macro.blocked():
-                    out = _inner_func(*args, **kwargs)
-                return out
-
-        else:
-
-            @functools_wraps(obj)
-            def func(*args, **kwargs):
-                return _inner_func(*args, **kwargs)
+        func = functools_wraps(obj)(wrapper(obj, parent=self))
 
         # Signature must be updated like this. Otherwise, already wrapped member function
         # will have signature with "self".
-        func.__signature__ = inspect.signature(obj)
+        obj_sig = inspect.signature(obj)
+        func.__signature__ = obj_sig
 
         # Prepare a button or action
         widget.tooltip = extract_tooltip(func)
@@ -578,15 +567,11 @@ class MagicTemplate:
         n_empty = len([_widget for _widget in fgui if isinstance(_widget, EmptyWidget)])
         nparams = _n_parameters(func) - n_empty
 
-        obj_sig = get_signature(obj)
         if isinstance(func.__signature__, MagicMethodSignature):
-            # NOTE: I don't know the reason why "additional_options" is lost.
             func.__signature__.additional_options = getattr(
                 obj_sig, "additional_options", {}
             )
 
-        # TODO: "update_widget" argument is useful.
-        # see https://github.com/napari/magicgui/pull/309
         if nparams == 0:
             # We don't want a dialog with a single widget "Run" to show up.
             def run_function():
@@ -594,14 +579,6 @@ class MagicTemplate:
                 # "compiled" otherwise function wrappings are not ready!
                 mgui = _build_mgui(widget, func, self)
                 mgui.native.setParent(self.native, mgui.native.windowFlags())
-                if (
-                    mgui.call_count == 0
-                    and len(mgui.called._slots) == 0
-                    and _need_record(func)
-                ):
-                    callback = _temporal_function_gui_callback(self, mgui, widget)
-                    mgui.called.connect(callback)
-
                 out = mgui()
 
                 return out
@@ -611,14 +588,6 @@ class MagicTemplate:
             def run_function():
                 mgui = _build_mgui(widget, func, self)
                 mgui.native.setParent(self.native, mgui.native.windowFlags())
-                if (
-                    mgui.call_count == 0
-                    and len(mgui.called._slots) == 0
-                    and _need_record(func)
-                ):
-                    callback = _temporal_function_gui_callback(self, mgui, widget)
-                    mgui.called.connect(callback)
-
                 fdialog: FileEdit = mgui[0]
                 result = fdialog._show_file_dialog(
                     fdialog.mode,
@@ -706,10 +675,6 @@ class MagicTemplate:
                         else:
                             # If FunctioGui is docked, we should close QDockWidget.
                             mgui.called.connect(lambda: mgui.parent.hide())
-
-                    if _need_record(func):
-                        callback = _temporal_function_gui_callback(self, mgui, widget)
-                        mgui.called.connect(callback)
 
                 if self._popup_mode != PopUpMode.dock:
                     widget.mgui.show()
@@ -919,76 +884,19 @@ def _get_widget_name(widget: Widget):
     return widget.name
 
 
-def _temporal_function_gui_callback(
-    bgui: MagicTemplate, fgui: FunctionGuiPlus, widget: PushButtonPlus
-):
-    if isinstance(fgui, FunctionGui):
-        _function = fgui._function
-    else:
-        raise TypeError("fgui must be FunctionGui object.")
-
-    return_type = fgui.return_annotation
-    result_required = return_type is not inspect.Parameter.empty
-
-    def _after_run(e: Exception = None):
-        if isinstance(e, Exception):
-            # If function call ended with an exception, don't record macro.
-            return
-        bound = fgui._previous_bound
-        result = Symbol("result")
-        # Standard button will be connected with two callbacks.
-        # 1. Build FunctionGui
-        # 2. Emit value changed signal.
-        # But if there are more, they also have to be called.
-        if len(widget.changed._slots) > 2:
-            b = Expr(head=Head.getitem, args=[symbol(bgui), widget.name])
-            ev = Expr(head=Head.getattr, args=[b, Symbol("changed")])
-            expr = Expr(head=Head.call, args=[ev])
-        else:
-            kwargs = {k: v for k, v in bound.arguments.items()}
-            expr = Expr.parse_method(bgui, _function, (), kwargs)
-
-        if fgui._auto_call:
-            # Auto-call will cause many redundant macros. To avoid this, only the last input
-            # will be recorded in magic-class.
-            last_expr = bgui.macro[-1]
-            if (
-                last_expr.head == Head.call
-                and last_expr.args[0].head == Head.getattr
-                and last_expr.at(0, 1) == expr.at(0, 1)
-                and len(bgui.macro) > 0
-            ):
-                bgui.macro.pop()
-                bgui.macro._erase_last()
-
-        if result_required:
-            expr = Expr(Head.assign, [result, expr])
-        bgui.macro.append(expr)
-
-        # Deal with return annotation
-
-        if result_required:
-            from magicgui.type_map import _type2callback
-
-            for callback in _type2callback(return_type):
-                b = Expr(head=Head.getitem, args=[symbol(bgui), widget.name])
-                _gui = Expr(head=Head.getattr, args=[b, Symbol("mgui")])
-                line = Expr.parse_call(callback, (_gui, result, return_type), {})
-                bgui.macro.append(line)
-        bgui.macro._last_setval = None
-        return None
-
-    return _after_run
-
-
 def _build_mgui(widget_: Action | PushButtonPlus, func: Callable, parent: BaseGui):
     if widget_.mgui is not None:
         return widget_.mgui
     try:
-        call_button = get_additional_option(func, "call_button", None)
-        layout = get_additional_option(func, "layout", "vertical")
-        labels = get_additional_option(func, "labels", True)
-        auto_call = get_additional_option(func, "auto_call", False)
+        sig = getattr(func, "__signature__", None)
+        if isinstance(sig, MagicMethodSignature):
+            opt = sig.additional_options
+        else:
+            opt = {}
+        call_button = opt.get("call_button", None)
+        layout = opt.get("layout", "vertical")
+        labels = opt.get("labels", True)
+        auto_call = opt.get("auto_call", False)
         mgui = FunctionGuiPlus(
             func, call_button, layout=layout, labels=labels, auto_call=auto_call
         )
@@ -1001,7 +909,7 @@ def _build_mgui(widget_: Action | PushButtonPlus, func: Callable, parent: BaseGu
 
     widget_.mgui = mgui
     name = widget_.name or ""
-    mgui.native.setWindowTitle(name.replace("_", " "))
+    mgui.native.setWindowTitle(name.replace("_", " ").strip())
     mgui._magicclass_parent_ref = weakref.ref(parent)
     return mgui
 
@@ -1218,10 +1126,6 @@ def _field_as_getter(bgui: BaseGui, fld: MagicField):
     return _func
 
 
-def _need_record(func: Callable):
-    return get_additional_option(func, "record", True)
-
-
 def _is_instance_method(self: MagicTemplate, func: Callable) -> bool:
     # NOTE: following implementation is not compatible with @wraps
     # if not callable(func):
@@ -1302,3 +1206,80 @@ def nested_function_gui_callback(gui: MagicTemplate, fgui: FunctionGui):
         gui.macro._last_setval = None
 
     return _after_run
+
+
+def _inject_recorder(func: Callable, is_method: bool = True) -> Callable:
+    sig = get_signature(func)
+    if is_method:
+        sig = sig.replace(
+            parameters=list(sig.parameters.values())[1:],
+            return_annotation=sig.return_annotation,
+        )
+        _func = func
+    else:
+
+        @functools_wraps(func)
+        def _func(self, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        # _self_param = inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        # _func.__signature__ = sig.replace(
+        #     parameters=[_self_param] + list(sig.parameters.values()),
+        #     return_annotation=sig.return_annotation,
+        # )
+
+    if isinstance(sig, MagicMethodSignature):
+        opt = sig.additional_options
+        _auto_call = opt.get("auto_call", False)
+    else:
+        _auto_call = False
+
+    @functools_wraps(_func)
+    def _recordable(bgui: MagicTemplate, *args, **kwargs):
+        with bgui.macro.blocked():
+            out = _func(bgui, *args, **kwargs)
+        if not bgui.macro.active:
+            return out
+        bound = sig.bind(*args, **kwargs)
+        kwargs = dict(bound.arguments.items())
+        expr = Expr.parse_method(bgui, _func, (), kwargs)
+
+        if _auto_call:
+            # Auto-call will cause many redundant macros. To avoid this, only the last input
+            # will be recorded in magic-class.
+            last_expr = bgui.macro[-1]
+            if (
+                last_expr.head == Head.call
+                and last_expr.args[0].head == Head.getattr
+                and last_expr.at(0, 1) == expr.at(0, 1)
+                and len(bgui.macro) > 0
+            ):
+                bgui.macro.pop()
+                bgui.macro._erase_last()
+
+        bgui.macro.append(expr)
+        bgui.macro._last_setval = None
+        return out
+
+    if hasattr(_func, "__signature__"):
+        _recordable.__signature__ = _func.__signature__
+    return _recordable
+
+
+_T = TypeVar("_T", bound=BaseGui)
+
+
+def convert_attributes(cls: type[_T]):
+    # update methods
+    _dict: dict[str, Callable] = {}
+    _pass = (property, classmethod, staticmethod, type, Widget)
+    for name, obj in cls.__dict__.items():
+        if name.startswith("_") or isinstance(obj, _pass) or not callable(obj):
+            new_attr = obj
+        elif callable(obj) and get_additional_option(obj, "record", True):
+            new_attr = _inject_recorder(obj)
+        else:
+            new_attr = obj
+
+        _dict[name] = new_attr
+    return _dict

--- a/magicclass/gui/_base.py
+++ b/magicclass/gui/_base.py
@@ -1222,11 +1222,11 @@ def _inject_recorder(func: Callable, is_method: bool = True) -> Callable:
         def _func(self, *args, **kwargs):
             return func(*args, **kwargs)
 
-        # _self_param = inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)
-        # _func.__signature__ = sig.replace(
-        #     parameters=[_self_param] + list(sig.parameters.values()),
-        #     return_annotation=sig.return_annotation,
-        # )
+        _self_param = inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        _func.__signature__ = sig.replace(
+            parameters=[_self_param] + list(sig.parameters.values()),
+            return_annotation=sig.return_annotation,
+        )
 
     if isinstance(sig, MagicMethodSignature):
         opt = sig.additional_options

--- a/magicclass/gui/_base.py
+++ b/magicclass/gui/_base.py
@@ -83,6 +83,7 @@ defaults = {
     "popup_mode": PopUpMode.popup,
     "error_mode": ErrorMode.msgbox,
     "close_on_run": True,
+    "macro-max-history": 1000,
 }
 
 _RESERVED = {
@@ -721,7 +722,10 @@ class MagicTemplate:
 
 class BaseGui(MagicTemplate):
     def __init__(self, close_on_run, popup_mode, error_mode):
-        self._macro_instance = GuiMacro(flags={"Get": False, "Return": False})
+        self._macro_instance = GuiMacro(
+            max_lines=defaults["macro-max-history"],
+            flags={"Get": False, "Return": False},
+        )
         self.__magicclass_parent__: BaseGui | None = None
         self.__magicclass_children__: list[MagicTemplate] = []
         self._close_on_run = close_on_run

--- a/magicclass/gui/_macro.py
+++ b/magicclass/gui/_macro.py
@@ -297,9 +297,10 @@ class MacroEdit(FreeWidget):
 
 
 class GuiMacro(Macro):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, max_lines: int, flags={}):
+        super().__init__(flags=flags)
         self._widget = None
+        self._max_lines = max_lines
         self.callbacks.append(self._update_widget)
 
     @property
@@ -316,6 +317,8 @@ class GuiMacro(Macro):
     def _update_widget(self, expr=None):
         if self.widget.synchronize:
             self.widget.textedit.append(str(self.args[-1]))
+        if len(self) > self._max_lines:
+            del self[0]
 
     def _erase_last(self):
         if self.widget.synchronize:

--- a/magicclass/gui/class_gui.py
+++ b/magicclass/gui/class_gui.py
@@ -353,21 +353,23 @@ def make_gui(container: type[_C], no_margin: bool = True) -> type[_C | ClassGuiB
             else:
                 object.__setattr__(self, name, value)
 
-        def _fast_insert(self: cls, key: int, widget: Widget | Callable) -> None:
-            if isinstance(widget, Callable):
+        def _fast_insert(self: cls, key: int, obj: Widget | Callable) -> None:
+            if isinstance(obj, Callable):
                 # Sometimes uses want to dynamically add new functions to GUI.
-                method_name = getattr(widget, "__name__", None)
-                if method_name and not hasattr(self, method_name):
-                    object.__setattr__(self, method_name, widget)
-
-                if isinstance(widget, FunctionGui):
-                    if widget.parent is None:
-                        f = nested_function_gui_callback(self, widget)
-                        widget.called.connect(f)
+                if isinstance(obj, FunctionGui):
+                    if obj.parent is None:
+                        f = nested_function_gui_callback(self, obj)
+                        obj.called.connect(f)
+                    widget = obj
                 else:
-                    widget = self._create_widget_from_method(
-                        _inject_recorder(widget, is_method=False)
-                    )
+                    obj = _inject_recorder(obj, is_method=False).__get__(self)
+                    widget = self._create_widget_from_method(obj)
+
+                method_name = getattr(obj, "__name__", None)
+                if method_name and not hasattr(self, method_name):
+                    object.__setattr__(self, method_name, obj)
+            else:
+                widget = obj
 
             # _hide_labels should not contain Container because some ValueWidget like widgets
             # are Containers.

--- a/magicclass/gui/class_gui.py
+++ b/magicclass/gui/class_gui.py
@@ -18,6 +18,7 @@ from ._base import (
     ErrorMode,
     value_widget_callback,
     nested_function_gui_callback,
+    _inject_recorder,
 )
 from .utils import (
     copy_class,
@@ -364,7 +365,9 @@ def make_gui(container: type[_C], no_margin: bool = True) -> type[_C | ClassGuiB
                         f = nested_function_gui_callback(self, widget)
                         widget.called.connect(f)
                 else:
-                    widget = self._create_widget_from_method(widget)
+                    widget = self._create_widget_from_method(
+                        _inject_recorder(widget, is_method=False)
+                    )
 
             # _hide_labels should not contain Container because some ValueWidget like widgets
             # are Containers.

--- a/magicclass/gui/menu_gui.py
+++ b/magicclass/gui/menu_gui.py
@@ -15,6 +15,7 @@ from ._base import (
     ErrorMode,
     ContainerLikeGui,
     nested_function_gui_callback,
+    _inject_recorder,
 )
 from .utils import MagicClassConstructionError, copy_class
 
@@ -181,7 +182,9 @@ class MenuGuiBase(ContainerLikeGui):
                     f = nested_function_gui_callback(self, obj)
                     obj.called.connect(f)
             else:
-                obj = self._create_widget_from_method(obj)
+                obj = self._create_widget_from_method(
+                    _inject_recorder(obj, is_method=False)
+                )
 
         if isinstance(obj, (self._component_class, MenuGuiBase)):
             insert_action_like(self.native, key, obj.native)

--- a/magicclass/gui/menu_gui.py
+++ b/magicclass/gui/menu_gui.py
@@ -172,35 +172,37 @@ class MenuGuiBase(ContainerLikeGui):
         self, key: int, obj: Callable | MenuGuiBase | AbstractAction
     ) -> None:
         if isinstance(obj, Callable):
-            # Sometimes uses want to dynamically add new functions to GUI.
-            method_name = getattr(obj, "__name__", None)
-            if method_name and not hasattr(self, method_name):
-                object.__setattr__(self, method_name, obj)
-
+            # Sometimes users want to dynamically add new functions to GUI.
             if isinstance(obj, FunctionGui):
                 if obj.parent is None:
                     f = nested_function_gui_callback(self, obj)
                     obj.called.connect(f)
+                _obj = obj
             else:
-                obj = self._create_widget_from_method(
-                    _inject_recorder(obj, is_method=False)
-                )
+                obj = _inject_recorder(obj, is_method=False).__get__(self)
+                _obj = self._create_widget_from_method(obj)
 
-        if isinstance(obj, (self._component_class, MenuGuiBase)):
-            insert_action_like(self.native, key, obj.native)
-            self._list.insert(key, obj)
+            method_name = getattr(obj, "__name__", None)
+            if method_name and not hasattr(self, method_name):
+                object.__setattr__(self, method_name, obj)
+        else:
+            _obj = obj
 
-        elif isinstance(obj, WidgetAction):
+        if isinstance(_obj, (self._component_class, MenuGuiBase)):
+            insert_action_like(self.native, key, _obj.native)
+            self._list.insert(key, _obj)
+
+        elif isinstance(_obj, WidgetAction):
             from .toolbar import ToolBarGui
 
-            if isinstance(obj.widget, Separator):
+            if isinstance(_obj.widget, Separator):
                 insert_action_like(self.native, key, "sep")
 
-            elif isinstance(obj.widget, ToolBarGui):
-                qmenu = QMenu(obj.widget.name, self.native)
-                qmenu.addAction(obj.native)
-                if obj.widget._icon_path is not None:
-                    qmenu.setIcon(obj.widget.native.windowIcon())
+            elif isinstance(_obj.widget, ToolBarGui):
+                qmenu = QMenu(_obj.widget.name, self.native)
+                qmenu.addAction(_obj.native)
+                if _obj.widget._icon_path is not None:
+                    qmenu.setIcon(_obj.widget.native.windowIcon())
                 insert_action_like(self.native, key, qmenu)
 
             else:
@@ -213,15 +215,15 @@ class MenuGuiBase(ContainerLikeGui):
                     Image,
                     Table,
                 )
-                _obj = obj
-                if (not isinstance(obj.widget, _hide_labels)) and self.labels:
-                    _obj = _LabeledWidgetAction.from_action(obj)
+                _obj = _obj
+                if (not isinstance(_obj.widget, _hide_labels)) and self.labels:
+                    _obj = _LabeledWidgetAction.from_action(_obj)
                 _obj.parent = self
                 insert_action_like(self.native, key, _obj.native)
 
-            self._list.insert(key, obj)
+            self._list.insert(key, _obj)
         else:
-            raise TypeError(f"{type(obj)} is not supported.")
+            raise TypeError(f"{type(_obj)} is not supported.")
 
     def insert(self, key: int, obj: Callable | MenuGuiBase | AbstractAction) -> None:
         """

--- a/magicclass/gui/toolbar.py
+++ b/magicclass/gui/toolbar.py
@@ -15,6 +15,7 @@ from ._base import (
     ErrorMode,
     ContainerLikeGui,
     nested_function_gui_callback,
+    _inject_recorder,
 )
 from .utils import MagicClassConstructionError, copy_class, set_context_menu
 from .menu_gui import ContextMenuGui, MenuGui, MenuGuiBase, insert_action_like
@@ -243,7 +244,9 @@ class ToolBarGui(ContainerLikeGui):
                     f = nested_function_gui_callback(self, obj)
                     obj.called.connect(f)
             else:
-                obj = self._create_widget_from_method(obj)
+                obj = self._create_widget_from_method(
+                    _inject_recorder(obj, is_method=False)
+                )
 
         # _hide_labels should not contain Container because some ValueWidget like widgets
         # are Containers.

--- a/magicclass/widgets/misc.py
+++ b/magicclass/widgets/misc.py
@@ -352,6 +352,17 @@ class ConsoleTextEdit(TextEdit):
         cursor.deletePreviousChar()
         self.native.setTextCursor(cursor)
 
+    def erase_first(self):
+        """Erase the first line."""
+        cursor = self.native.textCursor()
+        cursor.movePosition(QTextCursor.Start)
+        cursor.select(QTextCursor.LineUnderCursor)
+        cursor.removeSelectedText()
+        cursor.movePosition(QTextCursor.Down)
+        cursor.deletePreviousChar()
+        cursor.movePosition(QTextCursor.End)
+        self.native.setTextCursor(cursor)
+
     @property
     def selected(self) -> str:
         """Return selected string."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+from magicclass import defaults
+defaults["error_mode"] = "stderr"

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -33,7 +33,7 @@ def test_add_dock_widget():
 
 
 def test_post_append():
-    from types import FunctionType
+    from types import MethodType
 
     @magicclass
     class A:
@@ -57,11 +57,11 @@ def test_post_append():
     @ui.Tool.append
     def g(): pass
 
-    assert isinstance(ui.g, FunctionType)
+    assert isinstance(ui.g, MethodType)
     ui["g"]
-    assert isinstance(ui.Menu.g, FunctionType)
+    assert isinstance(ui.Menu.g, MethodType)
     ui.Menu["g"]
-    assert isinstance(ui.Tool.g, FunctionType)
+    assert isinstance(ui.Tool.g, MethodType)
     ui.Tool["g"]
 
     @ui.append

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -58,11 +58,15 @@ def test_post_append():
     def g(): pass
 
     assert isinstance(ui.g, FunctionType)
+    ui["g"]
     assert isinstance(ui.Menu.g, FunctionType)
+    ui.Menu["g"]
     assert isinstance(ui.Tool.g, FunctionType)
+    ui.Tool["g"]
 
     @ui.append
     def f(): pass
 
+    # the original method should not be updated
     ui.f()
     assert ui.a == 1


### PR DESCRIPTION
See #7.
Now method will be all recorded in macro no matter where it is called. This is done by following strategies:
1. A class is wrapped with, let's say `@magicclass`.
2. All the methods are iterated by `cls.__dict__.items()` and non-private methods are stored in a dictionary, `new_attr`.
3. When `@magicclass` create a new class it uses `type` constructor to inherit `ClassGui` and the user defined class. here `new_attr` is passed to the constructor like `new_class = type("new_class_name", (ClassGui, UserDefinedClass), new_attr)`