### PR TITLE
Interactive matplotlib figure widget

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4742f39f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from magicclass import magicclass, field\n",
+    "from magicclass.widgets import Figure, Logger\n",
+    "from magicclass.ext.jupyter import show_in_jupyter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "73ea28b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@magicclass(widget_type=\"mainwindow\")\n",
+    "class A:\n",
+    "    plt = field(Figure)\n",
+    "    log = field(Logger)\n",
+    "    def f(self):\n",
+    "        self.plt.cla()\n",
+    "        self.plt.plot(np.random.random(100))\n",
+    "ui = A()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b184ccba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "65c5a736788148e4aa1ef75d015bc868",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "RFBOutputContext()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='initial-snapshot-5aa8eb2e41244a2c82028e0484b272ed' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAAEsCAYAAAA1u0HIAAAKt0lEQVR42u3dP2tTewDG8SxOvgIHdze3QEHxTYirGergi3DUTC6ii4svIFtRcHSstGSpVNGq9N9iF1GkpQ6/62nTml5bjTR6znn8fOHD1RpKyA3n6UnSpPPx48cCALRbp+4rAACcnkEHgAAGHQACGHQACGDQASCAQQeAAAYdAAIYdAAIYNABIIBBB4AABh0AAhh0AAhg0AEggEEHgAAGHQACGHQACGDQASCAQQeAAAYdAAIYdAAIYNABIIBBB4AABh0AAhh0AAhg0AEggEEHgAAGHQACGHQACGDQASCAQQeAAAYdAAIYdAAIYNABIIBBB4AABh0AAjRu0DudTit8/vy5XL9+vfbrAUA96t5Lgz4lBh3g31b3Xhr0KZlk0G/cuFEWFhb2fPr06fDPABzvw4cPtR/fDbpB/6nqjlr3dQZoujYdK+veS4M+JQYdYPradKysey8N+pQYdIDpa9Oxsu69NOincPbs2XLx4sU9X758Kbdu3dr78/nz56PupAB1adOxsu69NOincOXKlXJcjx49irqTAtSlTcfKuvfSoLuTAjRWm46Vde+lQXcnBWisNh0r695Lg+5OCtBYbTpW1r2XBn0Kbt68Wd69e1e2t7fL4uJiuXTpUtSdFKAubTpW1r2XBv2Url27VnZ3d8vs7Gy5cOFCuXfv3t6vsP3qle5tupMC1KVNx8q699Kgn9L8/Hx5+PDhka+9fv263LlzJ+ZOClCXNh0r695Lg34KZ86cKV+/fi1Xr1498vX79++XZ8+exdxJAerSpmNl3Xtp0E/h3Llze793fvny5SNfr95g5tWrVzF3UoC6tOlYWfdeGvRT+N1BH/+0teoFdHV/ilETvH//vvbr0ARuB7eF2+F41SdT1n2sN+j/wKB7yP3f+unb7eC2cDu4HX6m7r1s/KADAL/PoANAAIMOAAEMOgAEMOgAEMCgA0AAgw4AAQw6AAQw6AAQwKADQACDDgABDDoABDDoABDAoANAAIMOAAEMOgAEMOgAEMCgA0AAgw4AAQw6AAQw6AAQwKADQACDDgABDDoABDDoABDAoANAAIMOAAEMOgAEMOgAEMCgA0AAgz6hra2tsrGxUdbW1gDg1N6+fVs2NzcN+t+2vr5eJEmaZisrKwb9b6t+mpIkaZq9efPGoBt0SVLbM+gGXZIUkEE36JKkgAy6QZckBWTQDbokKSCDbtAlSQEZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUkEE36JKkgAy6QZckBWTQDbokKSCDbtAlSQEZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUkEE36JKkgAy6QZckBWTQDbokKSCDbtAlSQEZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUkEE36JKkgAy6QZckBWTQDbokKSCDbtAlSQEZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUkEE36JKkgAy6QZckBWTQDbokKSCDbtAlSQEZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUkEE36JKkgAy6QZckBWTQDbokKSCDbtAlSQEZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUkEE36JKkgAy6QZckBWTQDbokKSCDbtAlSQEZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUkEE36JKkgJo76MNhGQwGZTCsf4ANuiSp6TV30Ae90ul0Src/rH2ADbokqekZdIMuSQrIoBt0SVJABt2gS5ICMugGXZIUUDsHfTgovW5379/3fPtzb3DS8A/LoNct3cPL9kr/22UH/d7oa70yMOiSpJbXukEf9o8OeXds2Lu9wQ/fZ9AbG/3/DXuvV+kbdElS62vXoA/7o0Hulv7476dXZ+yjoe4NPv54+W6/DH/2NYMuSWp5rRr0g7PtYx+GH13+yFAfe5Y/LP3uMT8UGHRJUotr0aD/aogPztLH/v1g5I88FH/wff7+c+cGXZL0p2rRoB8z2EccN/gHX6u+z6AMh/svkPtx5A26JKndtWjQJz1DHz/zrl4N3/n+IrqxF8TVdXZu0CVJf6IWDfrvP4e+f/nReI8+7GXYgA97MeiSpGnXqkEff5X7kd87P+FV7oc/APT6pV99cttg/2H3PQZdkhRUuwZ9/Ex8NOzdsYfUfzxzP+Eh98OH3uv51TWDLkmado0e9OpNY3onvFNcv3cw5tV/99/97ejlRs+5V8+Xj87KB6Oz9MGgfzj0dby1rEGXJE275g76aY0enj9xsA8evq/h1e4GXZI07XIHfexV7/2D580PjJ2hH3lnOYMuSWppwYO+fxZ+8nPoP/tAF4MuSWpX2YPeUAZdkjTtDLpBlyQFZNANuiQpIINu0CVJARl0gy5JCsigG3RJUkAG3aBLkgIy6AZdkhSQQTfokqSADLpBlyQFZNANuiQpIINu0CVJARl0gy5JCsigG3RJUkAG3aBLkgIy6AZdkhSQQTfokqSADLpBlyQFZNANuiQpIINu0CVJARl0gy5JCsigG3RJUkAG3aBLkgIy6AZdkhSQQTfokqSADLpBlyQFZNANuiQpIINu0CVJARl0gy5JCsigG3RJUkAG3aBLkgIy6AZdkhSQQTfokqSADLpBlyQFZNANuiQpIINu0CVJARl0gy5JCsigG3RJUkAG3aBLkgIy6AZdkhSQQTfokqSADLpBlyQFZNANuiQpIINu0CVJARl0gy5JCsigG3RJUkAG3aBLkgIy6AZdkhSQQTfokqSADLpBlyQFZNANuiQpIINu0CVJARl0gy5JCsigG3RJUkAG3aBLkgIy6AZdkhSQQa/B+vp63f/fJUlhraysGPS/bWtrqzx48KDcvn0bAE6t2pRqWww6AHDIoANAAIMOAAEMOgAEMOgAEMCgA0AAgw4AAQw6AAQw6AAQwKADQACDDgABDDoABDDoABBg6oNefXLM0tJSWVhYKM+fPwcAxiwvL0/1U9b+yKBXV7Aa8tXV1bK9vV12d3cBgJFqGzc2Nsri4uLUR32qg1791FFd0bpvMABosrW1tfLixYvmDnr1UIIzcwD4uZ2dnb2z9EYPet03EgC0QbWZBh0AWs6gA0AAgw4AAQw6AAQw6AAQwKADQACDDgABDDoABDDoABDAoAO/bXlurswdWK7/+gAGHfgtc2V2plM6nXEz5a5Rh9oZdGBiy3dn9kd89u7epyFW5mZnnaVDAxh0YGJzs87IoakMOjCh5XJ3xqBDUxl0YEIGHZrMoAO/UL0QbqbMzMx8fyHc6O+V2bm6rx9QMejALxh0aAODDkzIQ+7QZAYdmJBBhyYz6MCEDDo0mUEHJmTQockMOjAhgw5NZtCBCRl0aDKDDkzIoEOTGXRgQgYdmsygAxP6Nuiz1ZvJzBp0aCCDDgABDDoABDDoABDAoANAAIMOAAEMOgAEMOgAEMCgA0AAgw4AARo96AsLC2V7e7v2GwkAmmxnZ6fZg760tFRWV1drv6EAoMk2NjbKy5cvmzvoW1tbe2fpm5ubztQB4H+qbaxOfKutrDazsYN+MOrVwwhPnjwpjx8/BgBGnj59Wubn56c+5n9k0AGAv8+gA0AAgw4AAQw6AAQw6AAQwKADQACDDgABDDoABDDoABDAoANAAIMOAAEMOgAEMOgAEMCgA0AAgw4AAQw6AAQw6AAQwKADQACDDgAB/gNWHOnDB5BV3wAAAABJRU5ErkJggg==' style='width:500.0px;height:300.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
+      ],
+      "text/plain": [
+       "<jupyter_rfb._utils.Snapshot object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5aa8eb2e41244a2c82028e0484b272ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "JupyterQWidget()"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<PyQt5.QtGui.QMouseEvent object at 0x000001F01E5B7550>\n"
+     ]
+    }
+   ],
+   "source": [
+    "show_in_jupyter(ui)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2b2bfb26",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'numpy.ndarray'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "with ui.log.set_plt():\n",
+    "    plt.plot(np.arange(10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "670afbd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ui.f()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1c450550",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyqtgraph.jupyter import PlotWidget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "528c7669",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%gui qt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "21ec6ce4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3ed67c4f3b9042e6a7349e774a7e77f9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "RFBOutputContext()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class='initial-snapshot-24a3d3d920824684999f169238ccbf69' style='position:relative;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAAEsCAYAAAA1u0HIAAARi0lEQVR42u3du1IjyxIF0PkmPgCbCDxMTDwsLBwcHBwMHIzzu9xIxS3UKfQi6SalmWWsOKruVimnjtBW9Ut//vz587Gkh4eHj//++2/136VfCwD+Ycu+wHcDPbbd5gQGCgBO2bIvUAn0ExgUADg3y76AQAeAX7HsCwh0APgVy76AQAeAX7HsCwh0APgVy76AQAeAX7HsCwh0APgVy77A3d3dx8vLy+q/x2wv0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gKSCPSLi4uV7loA4Iy0F5CYoQNASXsBiUAHgJL2AhKBDgAl7QUkAh0AStoLSAQ6AJS0F5AIdAAoaS8gEegAUNJeQCLQAaCkvYBEoANASXsBiUAHgJL2AhKBDgAl7QUkAh0AStoLSAQ6AJS0F5AIdAAoaS8gEegAUNJeQCLQAaCkvYBEoANASXsBiUAHgJL2AhKBDgAl7QUkAh0ASravuLu7+3h4eFiJx5XOb29vP/uIx8c8R6ADQElecHV19fH29rYK1qlYFuuO7fj19fVLH7Hs0PMEOgCU5AUjzCN8b25uVkY4x7pjOn15ednZR6zb91yBDgAl68b9/f3O4B5BH9vs6zBm8bHd+/v7l3WxLNbtm+kLdAAoWTfGLHpbaI+wP7TbPI6375qJj5n7vi8FAh0AStaNcaw7dpFvbhjLxvp9HR4T6PtOshPoAFCybozAvry8/LJhLDsm0Md2+3a5b+t/WsMJDAoAnJt141BgHxPoYczSY/d8XK4Wxu78Q5fAxTbX19efTmCAAOAcrBtzBXp4enr6ctlaLDv0PDN0AChZN+YK9BHmz8/PnzP0eHxMqAt0AChZN+YI9HE2fAT45jpnuQPAYtaNOc5yH6G97VavsezQzWUEOgCUrBv7bh4zTnQ7dLe4Eej7vhQIdACY3brx+Pi4M7RHUMc2+zrct93oX6ADwOzWjbg+fFwrPj15bZzkFuv2XUMexkw+tp3O0uPx6NuNZQBgdnlBHOcewTsVy7YdF4918fOo02XTS9bi+vPpL685yx0AFvF1YczCI3hj13iIx7tm5rF+24w7lsW6+CIQdm23SaADQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJe0FJBHoFxcXK921AMAZaS8gMUMHgJL2AhKBDgAl7QUkAh0AStoLSAQ6AJS0F5AIdAAoaS8gEegAUNJeQCLQAaCkvYBEoANASXsBiUAHgJL2AhKBDgAl7QUkAh0AStoLSAQ6AJS0F5AIdAAoaS8gEegAUNJeQCLQAaCkvYBEoANASXsBiUAHgJL2AhKBDgAl7QUkAh0ASravuLu7+3h4eFiJx5XOLy8vP+7v77/Vh0AHgJK84Orq6uPt7W0VrFOxLNYd23EE+Pv7e+oj2of6EOgAUJIXjDB/fX39uLm5WYnHI9SP6TRCe4R4zM6jj+fn589Q3/dcgQ4AJetG7B7fFdwj6GObQ52O8N7cdnwx2Lf7XaADQMm6MQJ3W2iPsI9t9nUYx813zcQfHx8/Xl5eBDoAzG/dGLvJYxf55oaxbKzf12GEdWwTwV0pSKADQMm6MQI7ZtmbG46Z96HAjWPm49h5HEufHn8/Zne9QAeAknXjUGAfE+hPT0+rbeI4eux2jyCP2fp4bux23/d8gQ4AJevGHIE+De8I97F87IrftQdg+hrX19efTmCAAOAcrBtzBvq2k+LG7vfYHb/vNU5gUADg3KwbcwT6uGRt20lxsbt97I7f9xonMCgAcG7WjTnOch8nxW0L9H3rpjWcwKAAwLlZN/bdPGYcAz90t7h9l62NE+amx9Y3CXQAKFk3xi7xbaE9jo0fOkt9ennb5slv+25cMwh0AChZNyKAxw+qTGfRY2Yd6/adoT6M8J8eK//OWe4nMCgAcG7ygtvb2y+/kjbCPNZtbr/rrPUxG4/njceH7uM++juBQQGAc/N1YcygY1YeM+0Qj3fNqvfdmz2CPnbfR6jHbH3bF4JNAh0AStoLSAQ6AJS0F5AIdAAoaS8gEegAUNJeQCLQAaCkvYBEoANASXsBiUAHgJL2AhKBDgAl7QUkAh0AStoLSAQ6AJS0F5AIdAAoaS8gEegAUNJeQCLQAaCkvYBEoANASXsBiUAHgJL2AhKBDgAl7QUkAh0AStoLSAQ6AJS0F5AIdAAoaS8gEegAUNJeQBKBfnFxsdJdCwCckfYCEjN0AChpLyAR6ABQ0l5AItABoKS9gESgA0BJewGJQAeAkvYCEoEOACXtBSQCHQBK2gtIBDoAlLQXkAh0AChpLyAR6ABQ0l5AItABoKS9gESgA0BJewGJQAeAkvYCEoEOACXtBSQCHQBK2gtIBDoAlLQXkAh0AChpLyAR6ABQ0l5AItABoGT7iru7u4+Hh4eVePzTFxp9XV5e7t1OoANASV5wdXX18fb2tgrWqVgW6yovEkE++rm5udm7rUAHgJK8YIT56+vrKnxDPB6h/t0XiBn5+/u7QAeAZa0b9/f3O4N7BH1s850XeHl5STN9gQ4Ai1g3xkx8W2iPsI9tju389vZ29ZyYoY++BToALGLd2DeLjmVj/bGdj1l9BPuYqQt0AFjEujECe9uZ6LHsO4H++Pi42vb5+XnVFugAsKh141BgHxvocTb82NU+ln0n0K+vrz+dwAABwDlYN+YK9BHe02PxZugAsKh1Y45AHyfPRYBPlwt0AFjUujFHoI9rzuPucuM69um17BH4+0JdoANAyboxx1num3eY22Xf809gUADg3Kwb+24eEzPuY+4WF7vWtxkz95ipb+6OnxLoAFCyboxLzbaF9jgGHttUXsgxdABY1Loxve/609PT5/J4PC5DO/RrabsIdABYVF4Qd3Wb/pjKEMti3eb2sS5+Te3QCwl0AFjU14UxC49Z+Tj+HY93zcxj/TG/lx676mPbQz/BKtABoKS9gESgA0BJewGJQAeAkvYCEoEOACXtBSQCHQBK2gtIBDoAlLQXkAh0AChpLyAR6ABQ0l5AItABoKS9gESgA0BJewGJQAeAkvYCEoEOACXtBSQCHQBK2gtIBDoAlLQXkAh0AChpLyAR6ABQ0l5AItABoKS9gESgA0BJewGJQAeAkvYCkgj0i4uLle5aAOCMtBeQmKEDQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJdtX3N3dfTw8PKzE40rnV1dXn33c3t4e9RyBDgAleUGE8Nvb2ypYp2JZrDu246enp1IfAh0ASvKCEeavr68fNzc3K/F4BPIxncaMPLZ/f39fze5jdn5sHwIdAErWjfv7+52hO4I+tjnUaQR5bBtfBrYt37f7XaADQMm6MWbR20J7hH1ss6/DCPExO99c9/LysloXM/hdzxfoAFCyboxj3Zsz6zCC+lDgjuCP8N5cN74wCHQAmN26MQL78vLyy4ax7JhAj+0i/DdPfps+f9sXhmkNJzAoAHBu1o1DgX1MoO/y/PzspDgAWM66sVSgPz4+fj73mMvWrq+vP53AAAHAOVg3lgj0uGxtPO+YG9SYoQNAyboxd6BPwzxm6cc8R6ADQMm6McdZ7kNcaz62j7vGHVuQQAeAknVj381jxmz7mLvFxXHycROZOBnuOwUJdAAoWTfGyWvbQnvcFOaYXefT28d+tyCBDgAl60ZcKz5m1tPd5OOHVmLdtmvUp6b3cT+07TYCHQBK8oI49j1CfSqWbbsH++ad38ZMfp9td5Gb9ncCgwIA5+brwphZx6w8gjfE412z7Vg/vRxNoANAi/YCEoEOACXtBSQCHQBK2gtIBDoAlLQXkAh0AChpLyAR6ABQ0l5AItABoKS9gESgA0BJewGJQAeAkvYCEoEOACXtBSQCHQBK2gtIBDoAlLQXkAh0AChpLyAR6ABQ0l5AItABoKS9gESgA0BJewGJQAeAkvYCEoEOACXtBSQCHQBK2gtIBDoAlLQXkESgX1xcrHTXAgBnpL2AxAwdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKGkvIBHoAFDSXkAi0AGgpL2ARKADQEl7AYlAB4CS9gISgQ4AJe0FJAIdAEraC0gEOgCUtBeQCHQAKFmu87u7u4+Hh4eVeHzMcwQ6AJTM3+nV1dXH29vbKpynYlms2/dcgQ4AJfN3OsL89fX14+bmZiUej1Df91yBDgAl83Z4f3+/M7hH0Mc2u54v0AHge/6fnfN2Ombi20J7hH1sc6Aofsn19XV7Df8aY268/3bG/PctEujjeHnsZt9cF8vG+gNFnZ2Li4v2Gv6lP7xzHW9jbryN+ek61/EOiwb65eXll3WxTKCfFn94xvxvH/NzHW9jbry/Y9FA/8n67oH5l94I/vCM+d8+5uc63sbceH/HyQY6APA9JxfoAEDJvB0KdABoMW+HI7CrZ7kDACXzdrjv5jFxP/dYd+hucQDAt83b4ePj487Qfnl5Wa2LbU7gHw4Af5N5O4xrzd/f31fB/fT09Lk8HseyWLftGvXKL7Ox2xzjGT+kM/q4vb1t/zedsrnfv6OvbX8rzDfmMb6xN9Hnzu+Md3yO+ExZ7v/PnyU6jv9RI9SnYtnm/8Sf/DIbX801nuMLmP8nvzPeU/Fht+9clH/dXGMeH4Cbn1PR9h5fZrzHbcGn9t0GnO+J9+6fpTqPb74RCrGbPcTjbbONn/wyG1/NMZ4jUOINEh968SXM/5Plxnvz72YaMgJ9mTGPIBpjHO/36OP5+fnzfd/9bzwlc4z3ONy6rY9Y1/1vPGfxmTHG8k9nIT/9ZTaWGc8RKJthMpbbVbbc+3d88An0Zcd8hPfmtuOD0e73+cZ7fHna9kVpfKbYK1Kz+I1lvuOnv8zG/OM5Li3c9sc3wiZmNN3/1lMw9/s3viiNsR99C/T5x3z8psS293icsBvvc4E+33iPq5u2zcTHZ4qJ28+Mvap/Ootwzfrpjef4I932xzf+uAX6Mu/fMeOJYB8fdAJ9/jHfFzD87niP97kvUD9zUoFe/WU25h/P2C7+UDd3gU2fL2Tmf/+Oyz1jV3C0BfpyYz4+/OK/8T6fHg82U1zmM+XQLndXc/zMSQV6dT2/N57jmKOT4uYf723HGAX6cmM+ruCI93SMebynp+cuuE/G/O/xMUuPL0+xB2p6oq3Z+c8J9L/QUuM5Zo9OXllmvLcdRxToy435NLyn98oYoWPGuMxnyrZLYafjT51A/wstMZ7TDznfpOcf713nLAj05cZ8jO22XcDOE1nmM2W6V2TM0MdeP6H+cwL9LzT3eE7D3G7IZcZ7HEOMsR7X506v0Y3AF+rzjvkIkm0naW2ey/Cvm/NL67YxdZb7PE4q0J3lfnrjOS6h8g162fHe3AW5S/e/9VTMMebjw29boO9b9y+aY7xHaG+7f8X4nDHeP3MSge6X2U5zPOM4+Zg5mqksO97jToqbxvjHTN2H3bxjvu8yqrFr2JfYed/jh74UeI//zEkEul9mO83xnN7qsfvfdMqWfP86hr7cmE8vt9o8+W3fjVT+RXOM977tRv8C/WdOItABgHn8D2IzI41J1eyiAAAAAElFTkSuQmCC' style='width:500.0px;height:300.0px;' /><div style='position: absolute; top:0; left:0; padding:1px 3px; background: #777; color:#fff; font-size: 90%; font-family:sans-serif; '>initial snapshot</div></div>"
+      ],
+      "text/plain": [
+       "<jupyter_rfb._utils.Snapshot object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "24a3d3d920824684999f169238ccbf69",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "PlotWidget()"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ui = PlotWidget()\n",
+    "ui"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d037984f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<pyqtgraph.graphicsItems.PlotDataItem.PlotDataItem at 0x2a6b04070d0>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ui.plot(np.random.random(100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "912d41fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<PyQt5.QtWidgets.QWidget at 0x2a6b0455670>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ui.gfxView.viewport()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d672251f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/magicclass/widgets/_mpl_canvas.py
+++ b/magicclass/widgets/_mpl_canvas.py
@@ -9,8 +9,6 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from matplotlib.axes import Axes
 
-# TODO: log-scale and interactivity is not compatible
-
 
 class InteractiveFigureCanvas(FigureCanvas):
     """A figure canvas implemented with mouse callbacks."""
@@ -38,23 +36,10 @@ class InteractiveFigureCanvas(FigureCanvas):
             return
         delta = event.angleDelta().y() / 120
         event = self.get_mouse_event(event)
+        factor = 0.75 ** delta
 
-        x0, x1 = ax.get_xlim()
-        y0, y1 = ax.get_ylim()
-        xrange = x1 - x0
-        yrange = y1 - y0
-
-        if delta > 0:
-            factor = 1 / 1.3
-        else:
-            factor = 1.3
-
-        ax.set_xlim(
-            [(x1 + x0) / 2 - xrange / 2 * factor, (x1 + x0) / 2 + xrange / 2 * factor]
-        )
-        ax.set_ylim(
-            [(y1 + y0) / 2 - yrange / 2 * factor, (y1 + y0) / 2 + yrange / 2 * factor]
-        )
+        _zoom_x_wheel(ax, factor)
+        _zoom_y_wheel(ax, factor)
         self.figure.canvas.draw()
         return None
 
@@ -89,24 +74,12 @@ class InteractiveFigureCanvas(FigureCanvas):
         if x is None or y is None:
             return None
 
-        x0, x1 = ax.get_xlim()
-        y0, y1 = ax.get_ylim()
         if self.pressed == MouseButton.LEFT:
-            distx = x - self.lastx_pressed
-            disty = y - self.lasty_pressed
-            ax.set_xlim([x0 - distx, x1 - distx])
-            ax.set_ylim([y0 - disty, y1 - disty])
+            _translate_x(ax, self.lastx_pressed, x)
+            _translate_y(ax, self.lasty_pressed, y)
         elif self.pressed == MouseButton.RIGHT:
-            dx = x - self.lastx
-            dy = y - self.lasty
-            xrange = x1 - x0
-            yrange = y1 - y0
-            ax.set_xlim(
-                [(x1 + x0) / 2 - xrange / 2 + dx, (x1 + x0) / 2 + xrange / 2 - dx]
-            )
-            ax.set_ylim(
-                [(y1 + y0) / 2 - yrange / 2 + dy, (y1 + y0) / 2 + yrange / 2 - dy]
-            )
+            _zoom_x(ax, self.lastx, x)
+            _zoom_y(ax, self.lasty, y)
 
         self.lastx, self.lasty = x, y
         self.figure.canvas.draw()
@@ -183,3 +156,96 @@ class InteractiveFigureCanvas(FigureCanvas):
         h, w, _ = arr.shape
         image = QtGui.QImage(arr, w, h, QtGui.QImage.Format_RGBA8888)
         clipboard.setImage(image)
+
+
+def _translate_x(ax: Axes, xstart: float, xstop: float):
+    xscale = ax.get_xscale()
+    x0, x1 = ax.get_xlim()
+    if xscale == "linear":
+        dx = xstop - xstart
+        ax.set_xlim([x0 - dx, x1 - dx])
+    elif xscale == "log":
+        if xstart <= 0 or xstop <= 0:
+            ax.autoscale(axis="x")
+        else:
+            ratio = xstart / xstop
+            ax.set_xlim([x0 * ratio, x1 * ratio])
+
+
+def _translate_y(ax: Axes, ystart: float, ystop: float):
+    yscale = ax.get_yscale()
+    y0, y1 = ax.get_ylim()
+    if yscale == "linear":
+        dy = ystop - ystart
+        ax.set_ylim([y0 - dy, y1 - dy])
+    elif yscale == "log":
+        if ystart <= 0 or ystop <= 0:
+            ax.autoscale(axis="y")
+        else:
+            ratio = ystart / ystop
+            ax.set_ylim([y0 * ratio, y1 * ratio])
+
+
+def _zoom_x(ax: Axes, xstart: float, xstop: float):
+    xscale = ax.get_xscale()
+    x0, x1 = ax.get_xlim()
+    if xscale == "linear":
+        _u = x1 + x0
+        _v = x1 - x0
+        dx = xstop - xstart
+        ax.set_xlim([_u / 2 - _v / 2 + dx, _u / 2 + _v / 2 - dx])
+    elif xscale == "log":
+        if xstart <= 0 or xstop <= 0:
+            ax.autoscale(axis="x")
+        ratio = xstop / xstart
+        ax.set_xlim([x0 * ratio, x1 / ratio])
+
+
+def _zoom_y(ax: Axes, ystart: float, ystop: float):
+    yscale = ax.get_yscale()
+    y0, y1 = ax.get_ylim()
+    if yscale == "linear":
+        _u = y1 + y0
+        _v = y1 - y0
+        dy = ystop - ystart
+        ax.set_ylim([_u / 2 - _v / 2 + dy, _u / 2 + _v / 2 - dy])
+    elif yscale == "log":
+        if ystart <= 0 or ystop <= 0:
+            ax.autoscale(axis="y")
+        else:
+            ratio = ystop / ystart
+            ax.set_ylim([y0 * ratio, y1 / ratio])
+
+
+def _zoom_x_wheel(ax: Axes, factor: float):
+    xscale = ax.get_xscale()
+    x0, x1 = ax.get_xlim()
+    if xscale == "linear":
+        _u = x1 + x0
+        _v = x1 - x0
+        ax.set_xlim([_u / 2 - _v / 2 * factor, _u / 2 + _v / 2 * factor])
+    elif xscale == "log":
+        if x0 <= 0 or x1 <= 0:
+            ax.autoscale(axis="x")
+        else:
+            xc = (x0 * x1) ** 0.5
+            x0_t = (x0 / xc) ** factor
+            x1_t = (x1 / xc) ** factor
+            ax.set_xlim([x0_t * xc, x1_t * xc])
+
+
+def _zoom_y_wheel(ax: Axes, factor: float):
+    yscale = ax.get_yscale()
+    y0, y1 = ax.get_ylim()
+    if yscale == "linear":
+        _u = y1 + y0
+        _v = y1 - y0
+        ax.set_ylim([_u / 2 - _v / 2 * factor, _u / 2 + _v / 2 * factor])
+    elif yscale == "log":
+        if y0 <= 0 or y1 <= 0:
+            ax.autoscale(axis="y")
+        else:
+            yc = (y0 * y1) ** 0.5
+            y0_t = (y0 / yc) ** factor
+            y1_t = (y1 / yc) ** factor
+            ax.set_ylim([y0_t * yc, y1_t * yc])

--- a/magicclass/widgets/_mpl_canvas.py
+++ b/magicclass/widgets/_mpl_canvas.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from matplotlib.axes import Axes
 
+# TODO: log-scale and interactivity is not compatible
+
 
 class InteractiveFigureCanvas(FigureCanvas):
     """A figure canvas implemented with mouse callbacks."""

--- a/magicclass/widgets/_mpl_canvas.py
+++ b/magicclass/widgets/_mpl_canvas.py
@@ -9,110 +9,126 @@ if TYPE_CHECKING:
 
 # TODO: use event loop, add callbacks
 
+
 class InteractiveFigureCanvas(FigureCanvas):
     """A figure canvas implemented with mouse callbacks."""
-    
+
     figure: Figure
-    
+
     def __init__(self, fig):
         super().__init__(fig)
         self.pressed = None
+        self.lastx_pressed = None
+        self.lasty_pressed = None
         self.lastx = None
         self.lasty = None
-        
+        self.last_axis: Axes | None = None
+
     def wheelEvent(self, event):
         """
         Resize figure by changing axes xlim and ylim. If there are subplots, only the subplot
         in which cursor exists will be resized.
-        """        
-        fig = self.figure
-        
+        """
         delta = event.angleDelta().y() / 120
         event = self.get_mouse_event(event)
-        
-        if not event.inaxes:
-            return None
-        for ax in fig.axes:
-            ax: Axes
-            if event.inaxes != ax:
-                continue
-            x0, x1 = ax.get_xlim()
-            y0, y1 = ax.get_ylim()
-            
-            if delta > 0:
-                factor = 1/1.3
-            else:
-                factor = 1.3
 
-            ax.set_xlim([(x1 + x0)/2 - (x1 - x0)/2*factor,
-                         (x1 + x0)/2 + (x1 - x0)/2*factor])
-            ax.set_ylim([(y1 + y0)/2 - (y1 - y0)/2*factor,
-                         (y1 + y0)/2 + (y1 - y0)/2*factor])
-            break
-        fig.canvas.draw()
+        ax = self.last_axis
+        if not ax:
+            return None
+
+        x0, x1 = ax.get_xlim()
+        y0, y1 = ax.get_ylim()
+        xrange = x1 - x0
+        yrange = y1 - y0
+
+        if delta > 0:
+            factor = 1 / 1.3
+        else:
+            factor = 1.3
+
+        ax.set_xlim(
+            [(x1 + x0) / 2 - xrange / 2 * factor, (x1 + x0) / 2 + xrange / 2 * factor]
+        )
+        ax.set_ylim(
+            [(y1 + y0) / 2 - yrange / 2 * factor, (y1 + y0) / 2 + yrange / 2 * factor]
+        )
+        self.figure.canvas.draw()
         return None
-    
+
     def mousePressEvent(self, event):
         """Record the starting coordinates of mouse drag."""
-        
+
         event = self.get_mouse_event(event)
-        self.lastx, self.lasty = event.xdata, event.ydata
+        self.lastx_pressed = self.lastx = event.xdata
+        self.lasty_pressed = self.lasty = event.ydata
         if event.inaxes:
             self.pressed = event.button
+            self.last_axis = event.inaxes
         return None
-        
+
     def mouseMoveEvent(self, event):
         """
         Translate axes focus while dragging. If there are subplots, only the subplot in which
         cursor exists will be translated.
-        """        
-        if self.pressed not in (MouseButton.LEFT, MouseButton.RIGHT) or self.lastx is None:
+        """
+        if (
+            self.pressed not in (MouseButton.LEFT, MouseButton.RIGHT)
+            or self.lastx_pressed is None
+        ):
             return None
-        fig = self.figure
-        
-        event = self.get_mouse_event(event)
-        
-        for ax in fig.axes:
-            if event.inaxes != ax:
-                continue
-            dx = event.xdata - self.lastx
-            dy = event.ydata - self.lasty
-            
-            x0, x1 = ax.get_xlim()
-            y0, y1 = ax.get_ylim()
-            if self.pressed is MouseButton.LEFT:
-                ax.set_xlim([x0 - dx, x1 - dx])
-                ax.set_ylim([y0 - dy, y1 - dy])
-            elif self.pressed is MouseButton.RIGHT:
-                ax.set_xlim([x0, x1 - dx])
-                ax.set_ylim([y0, y1 - dy])
-            break
 
-        fig.canvas.draw()
+        event = self.get_mouse_event(event)
+        ax = self.last_axis
+        if not ax:
+            return None
+        x, y = event.xdata, event.ydata
+
+        if x is None or y is None:
+            return None
+
+        x0, x1 = ax.get_xlim()
+        y0, y1 = ax.get_ylim()
+        if self.pressed == MouseButton.LEFT:
+            distx = x - self.lastx_pressed
+            disty = y - self.lasty_pressed
+            ax.set_xlim([x0 - distx, x1 - distx])
+            ax.set_ylim([y0 - disty, y1 - disty])
+        elif self.pressed == MouseButton.RIGHT:
+            dx = x - self.lastx
+            dy = y - self.lasty
+            xrange = x1 - x0
+            yrange = y1 - y0
+            ax.set_xlim(
+                [(x1 + x0) / 2 - xrange / 2 + dx, (x1 + x0) / 2 + xrange / 2 - dx]
+            )
+            ax.set_ylim(
+                [(y1 + y0) / 2 - yrange / 2 + dy, (y1 + y0) / 2 + yrange / 2 - dy]
+            )
+
+        self.lastx, self.lasty = x, y
+        self.figure.canvas.draw()
         return None
 
     def mouseReleaseEvent(self, event):
         """Stop dragging state."""
         self.pressed = None
         return None
-    
+
     def mouseDoubleClickEvent(self, event):
         """
         Adjust layout upon dougle click.
-        """        
+        """
         self.figure.tight_layout()
         self.figure.canvas.draw()
         return None
-    
+
     def resizeEvent(self, event):
-        """
-        Adjust layout upon canvas resized.
-        """        
+        """Adjust layout upon canvas resized."""
         super().resizeEvent(event)
         self.figure.tight_layout()
         self.figure.canvas.draw()
         return None
-    
+
     def get_mouse_event(self, event, name="") -> MouseEvent:
         x, y = self.mouseEventCoords(event)
         if hasattr(event, "button"):

--- a/magicclass/widgets/_mpl_canvas.py
+++ b/magicclass/widgets/_mpl_canvas.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backend_bases import MouseEvent, MouseButton
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+    from matplotlib.axes import Axes
+
+# TODO: use event loop, add callbacks
+
+class InteractiveFigureCanvas(FigureCanvas):
+    """A figure canvas implemented with mouse callbacks."""
+    
+    figure: Figure
+    
+    def __init__(self, fig):
+        super().__init__(fig)
+        self.pressed = None
+        self.lastx = None
+        self.lasty = None
+        
+    def wheelEvent(self, event):
+        """
+        Resize figure by changing axes xlim and ylim. If there are subplots, only the subplot
+        in which cursor exists will be resized.
+        """        
+        fig = self.figure
+        
+        delta = event.angleDelta().y() / 120
+        event = self.get_mouse_event(event)
+        
+        if not event.inaxes:
+            return None
+        for ax in fig.axes:
+            ax: Axes
+            if event.inaxes != ax:
+                continue
+            x0, x1 = ax.get_xlim()
+            y0, y1 = ax.get_ylim()
+            
+            if delta > 0:
+                factor = 1/1.3
+            else:
+                factor = 1.3
+
+            ax.set_xlim([(x1 + x0)/2 - (x1 - x0)/2*factor,
+                         (x1 + x0)/2 + (x1 - x0)/2*factor])
+            ax.set_ylim([(y1 + y0)/2 - (y1 - y0)/2*factor,
+                         (y1 + y0)/2 + (y1 - y0)/2*factor])
+            break
+        fig.canvas.draw()
+        return None
+    
+    def mousePressEvent(self, event):
+        """Record the starting coordinates of mouse drag."""
+        
+        event = self.get_mouse_event(event)
+        self.lastx, self.lasty = event.xdata, event.ydata
+        if event.inaxes:
+            self.pressed = event.button
+        return None
+        
+    def mouseMoveEvent(self, event):
+        """
+        Translate axes focus while dragging. If there are subplots, only the subplot in which
+        cursor exists will be translated.
+        """        
+        if self.pressed not in (MouseButton.LEFT, MouseButton.RIGHT) or self.lastx is None:
+            return None
+        fig = self.figure
+        
+        event = self.get_mouse_event(event)
+        
+        for ax in fig.axes:
+            if event.inaxes != ax:
+                continue
+            dx = event.xdata - self.lastx
+            dy = event.ydata - self.lasty
+            
+            x0, x1 = ax.get_xlim()
+            y0, y1 = ax.get_ylim()
+            if self.pressed is MouseButton.LEFT:
+                ax.set_xlim([x0 - dx, x1 - dx])
+                ax.set_ylim([y0 - dy, y1 - dy])
+            elif self.pressed is MouseButton.RIGHT:
+                ax.set_xlim([x0, x1 - dx])
+                ax.set_ylim([y0, y1 - dy])
+            break
+
+        fig.canvas.draw()
+        return None
+
+    def mouseReleaseEvent(self, event):
+        """Stop dragging state."""
+        self.pressed = None
+        return None
+    
+    def mouseDoubleClickEvent(self, event):
+        """
+        Adjust layout upon dougle click.
+        """        
+        self.figure.tight_layout()
+        self.figure.canvas.draw()
+        return None
+    
+    def resizeEvent(self, event):
+        """
+        Adjust layout upon canvas resized.
+        """        
+        super().resizeEvent(event)
+        self.figure.tight_layout()
+        self.figure.canvas.draw()
+        return None
+    
+    def get_mouse_event(self, event, name="") -> MouseEvent:
+        x, y = self.mouseEventCoords(event)
+        if hasattr(event, "button"):
+            button = self.buttond.get(event.button())
+        else:
+            button = None
+        mouse_event = MouseEvent(name, self, x, y, button=button, guiEvent=event)
+        return mouse_event

--- a/magicclass/widgets/_mpl_canvas.py
+++ b/magicclass/widgets/_mpl_canvas.py
@@ -23,18 +23,18 @@ class InteractiveFigureCanvas(FigureCanvas):
         self.lastx = None
         self.lasty = None
         self.last_axis: Axes | None = None
+        self._interactive = True
 
     def wheelEvent(self, event):
         """
         Resize figure by changing axes xlim and ylim. If there are subplots, only the subplot
         in which cursor exists will be resized.
         """
+        ax = self.last_axis
+        if not self._interactive or not ax:
+            return
         delta = event.angleDelta().y() / 120
         event = self.get_mouse_event(event)
-
-        ax = self.last_axis
-        if not ax:
-            return None
 
         x0, x1 = ax.get_xlim()
         y0, y1 = ax.get_ylim()
@@ -71,16 +71,16 @@ class InteractiveFigureCanvas(FigureCanvas):
         Translate axes focus while dragging. If there are subplots, only the subplot in which
         cursor exists will be translated.
         """
+        ax = self.last_axis
         if (
             self.pressed not in (MouseButton.LEFT, MouseButton.RIGHT)
             or self.lastx_pressed is None
+            or not self._interactive
+            or not ax
         ):
-            return None
+            return
 
         event = self.get_mouse_event(event)
-        ax = self.last_axis
-        if not ax:
-            return None
         x, y = event.xdata, event.ydata
 
         if x is None or y is None:
@@ -118,6 +118,8 @@ class InteractiveFigureCanvas(FigureCanvas):
         """
         Adjust layout upon dougle click.
         """
+        if not self._interactive:
+            return
         self.figure.tight_layout()
         self.figure.canvas.draw()
         return None

--- a/magicclass/widgets/misc.py
+++ b/magicclass/widgets/misc.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Generic, Iterable, MutableSequence, Any, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Generic,
+    Iterable,
+    MutableSequence,
+    Any,
+    TypeVar,
+)
 from typing_extensions import _AnnotatedAlias, get_args
 from psygnal import Signal
 from qtpy.QtWidgets import QTabWidget, QLineEdit, QMenu, QVBoxLayout, QWidget
@@ -173,6 +181,10 @@ class Figure(FreeWidget):
     @enabled.setter
     def enabled(self, v: bool):
         self.canvas._interactive = bool(v)
+
+    @property
+    def mouse_click_callbacks(self) -> list[Callable]:
+        return self.canvas._mouse_click_callbacks
 
     interactive = enabled  # alias
 

--- a/magicclass/widgets/misc.py
+++ b/magicclass/widgets/misc.py
@@ -125,7 +125,7 @@ class Figure(FreeWidget):
         self,
         nrows: int = 1,
         ncols: int = 1,
-        figsize: tuple[float, float] = (4., 3.),
+        figsize: tuple[float, float] = (4.0, 3.0),
         style=None,
         **kwargs,
     ):
@@ -144,8 +144,9 @@ class Figure(FreeWidget):
         finally:
             mpl.use(backend)
 
-        super().__init__(**kwargs)
         canvas = InteractiveFigureCanvas(fig)
+        self.canvas = canvas
+        super().__init__(**kwargs)
         self.set_widget(canvas)
         self.figure = fig
         self.min_height = 40
@@ -162,7 +163,18 @@ class Figure(FreeWidget):
     def draw(self):
         """Copy of ``plt.draw()``."""
         self.figure.tight_layout()
-        self.figure.canvas.draw()
+        self.canvas.draw()
+
+    @property
+    def enabled(self) -> bool:
+        """toggle interactivity of the figure canvas."""
+        return self.canvas._interactive
+
+    @enabled.setter
+    def enabled(self, v: bool):
+        self.canvas._interactive = bool(v)
+
+    interactive = enabled  # alias
 
     def clf(self):
         """Copy of ``plt.clf``."""

--- a/magicclass/widgets/misc.py
+++ b/magicclass/widgets/misc.py
@@ -368,6 +368,18 @@ class Figure(FreeWidget):
             on = not self.ax.get_frame_on()
         self.ax.set_frame_on(on)
 
+    def xscale(self, scale):
+        """Copy of ``plt.xscale``."""
+        self.ax.set_xscale(scale)
+        self.enabled = False
+        self.draw()
+
+    def yscale(self, scale):
+        """Copy of ``plt.yscale``."""
+        self.ax.set_yscale(scale)
+        self.enabled = False
+        self.draw()
+
 
 class ConsoleTextEdit(TextEdit):
     """A text edit with console-like setting."""

--- a/magicclass/widgets/misc.py
+++ b/magicclass/widgets/misc.py
@@ -19,7 +19,6 @@ from magicgui.widgets import LineEdit
 from magicgui.widgets._bases.value_widget import ValueWidget, UNSET
 from magicgui.backends._qtpy.widgets import (
     QBaseWidget,
-    QBaseValueWidget,
     LineEdit as BaseLineEdit,
 )
 from .utils import FreeWidget, merge_super_sigs
@@ -126,13 +125,13 @@ class Figure(FreeWidget):
         self,
         nrows: int = 1,
         ncols: int = 1,
-        figsize: tuple[int, int] = (4, 3),
+        figsize: tuple[float, float] = (4., 3.),
         style=None,
         **kwargs,
     ):
         import matplotlib as mpl
         import matplotlib.pyplot as plt
-        from matplotlib.backends.backend_qt5agg import FigureCanvas
+        from ._mpl_canvas import InteractiveFigureCanvas
 
         backend = mpl.get_backend()
         try:
@@ -146,7 +145,7 @@ class Figure(FreeWidget):
             mpl.use(backend)
 
         super().__init__(**kwargs)
-        canvas = FigureCanvas(fig)
+        canvas = InteractiveFigureCanvas(fig)
         self.set_widget(canvas)
         self.figure = fig
         self.min_height = 40

--- a/magicclass/widgets/misc.py
+++ b/magicclass/widgets/misc.py
@@ -210,6 +210,10 @@ class Figure(FreeWidget):
             _ax = self.figure.add_subplot(111)
         return _ax
 
+    def savefig(self, *args, **kwargs):
+        """Copy of ``plt.savefig``."""
+        return self.figure.savefig(*args, **kwargs)
+
     def plot(self, *args, **kwargs) -> Axes:
         """Copy of ``plt.plot``."""
         self.ax.plot(*args, **kwargs)
@@ -349,6 +353,20 @@ class Figure(FreeWidget):
             l.update(kwargs)
         self.draw()
         return locs, labels
+
+    def twinx(self) -> Axes:
+        """Copy of ``plt.twinx``."""
+        return self.ax.twinx()
+
+    def twiny(self) -> Axes:
+        """Copy of ``plt.twiny``."""
+        return self.ax.twiny()
+
+    def box(self, on=None) -> None:
+        """Copy of ``plt.box``."""
+        if on is None:
+            on = not self.ax.get_frame_on()
+        self.ax.set_frame_on(on)
 
 
 class ConsoleTextEdit(TextEdit):

--- a/magicclass/widgets/misc.py
+++ b/magicclass/widgets/misc.py
@@ -386,15 +386,18 @@ class Figure(FreeWidget):
         self.ax.set_frame_on(on)
 
     @_inject_mpl_docs
-    def xscale(self, scale):
+    def xscale(self, scale=None):
         self.ax.set_xscale(scale)
-        self.enabled = False
         self.draw()
 
     @_inject_mpl_docs
-    def yscale(self, scale):
+    def yscale(self, scale=None):
         self.ax.set_yscale(scale)
-        self.enabled = False
+        self.draw()
+
+    @_inject_mpl_docs
+    def autoscale(self, enable=True, axis="both", tight=None):
+        self.ax.autoscale(enable=enable, axis=axis, tight=tight)
         self.draw()
 
 


### PR DESCRIPTION
Related to the conversation in #10.
In terms of performance and extensibility, using `pyqtgraph` or `vispy` would be better solution, but supporting `matplotlib` should also be important because people install it in most of the environment and are very familiar with the API.

Todo
------

- [x] Better interactivity (especially the directional expansion with right click)
- [x] Support custom mouse callbacks.
- [x] Toggle interactivity.
- [x] A "Save image" and "Copy screenshot" context menu (should it be customizable?).

Example
---------
```python
from magicclass import magicclass, field
from magicclass.widgets import Figure
@magicclass
class A:
    plt = field(Figure)
ui = A()
ui.show()

ui.plt.plot(np.random.random(100))
```

https://user-images.githubusercontent.com/40591297/158547895-2c83dbc1-4034-4591-b03b-8baac9b4dd65.mp4

