### PR TITLE
Add `FieldGroup`

### DIFF
--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -21,7 +21,7 @@ from .wrappers import (
     nogui,
 )
 
-from .fields import field, vfield
+from .fields import field, vfield, FieldGroup
 from .gui._base import wraps, defaults, MagicTemplate, PopUpMode
 from .gui.keybinding import Key
 from . import widgets, utils, types


### PR DESCRIPTION
This idea came from `EventGroup` of [psygnal](https://github.com/tlambert03/psygnal).
When we need a set of value-widgets in magicclass (especially when we want to locally change layouts), currently we have to nest another class.

```python
from magicclass import magicclass, field

@magicclass
class Main:
    @magicclass
    class Parameters:
        a = field(float)
        s = field(str)

```

This is not favorable since we don't want to define a new class all the way just for a set of parameters. Also, nesting magicclass too much should be avoided because it disturbs typing a little bit.

`FieldGroup` is a subclass of `MagicField` that is composed of several fields. It always creates a `Container` widget. Following code is identical to the one above.

```python
from magicclass import magicclass, field, FieldGroup

# A group of fields
class Parameters(FieldGroup):
    a = field(float)
    s = field(str)

@magicclass
class Main:
    params = Parameters()
```

`FieldGroup` is also useful when you use `MagicField` outside magicclass since it is independent of `@magicclass` decorator.