### PR TITLE
More flexible usage of field objects

### DIFF
--- a/examples/use_field_in_napari.py
+++ b/examples/use_field_in_napari.py
@@ -1,0 +1,35 @@
+from scipy.ndimage import gaussian_filter
+from magicclass import HasFields, vfield
+import napari
+from napari.layers import Image
+from skimage import data
+
+class ImageGaussian(Image, HasFields):
+    """
+    An custom image layer implemented with Gaussian filter.
+
+    A Subclass of HasFields has `widgets` property that can collect all the MagicField
+    and createa a Container widget using `as_container()` method.
+    """
+
+    sigma = vfield(0.0, widget_type="FloatSlider", options={"max": 10, "step": 0.1})
+    edge = vfield("reflect", options={"choices": ["reflect", "constant", "mirror", "nearest"]})
+
+    @sigma.connect
+    @edge.connect
+    def _on_parameter_change(self):
+        img = gaussian_filter(self._data_original, self.sigma, mode=self.edge)
+        self.data = img
+
+    def __init__(self, data, *args, **kwargs):
+        self._data_original = data
+        super().__init__(data, *args, **kwargs)
+
+if __name__ == "__main__":
+    viewer = napari.Viewer()
+    img = data.camera()
+    layer = ImageGaussian(img)
+    viewer.add_layer(layer)
+    viewer.window.add_dock_widget(layer.widgets.as_container())
+
+    napari.run()

--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -22,7 +22,7 @@ from .wrappers import (
     mark_preview,
 )
 
-from .fields import field, vfield
+from .fields import field, vfield, FieldGroup
 from ._gui._base import wraps, defaults, MagicTemplate, PopUpMode
 from ._gui.keybinding import Key
 from . import widgets, utils, types
@@ -49,6 +49,7 @@ __all__ = [
     "mark_preview",
     "field",
     "vfield",
+    "FieldGroup",
     "wraps",
     "defaults",
     "MagicTemplate",

--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -22,7 +22,7 @@ from .wrappers import (
     mark_preview,
 )
 
-from .fields import field, vfield, FieldGroup
+from .fields import field, vfield, FieldGroup, HasFields
 from ._gui._base import wraps, defaults, MagicTemplate, PopUpMode
 from ._gui.keybinding import Key
 from . import widgets, utils, types

--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -49,7 +49,7 @@ from .mgui_ext import (
     _LabeledWidgetAction,
     mguiLike,
 )
-from .utils import get_parameters, define_callback, callable_to_classes
+from .utils import get_parameters, callable_to_classes
 from ._macro import GuiMacro
 
 from ..utils import (
@@ -818,17 +818,11 @@ class ContainerLikeGui(BaseGui, mguiLike, MutableSequence):
         fld.name = fld.name or name
         action = fld.get_action(self)
 
-        if action.support_value:
+        if action.support_value and fld.record:
             # By default, set value function will be connected to the widget.
-            if fld.record:
-                getvalue = type(fld) is MagicField
-                f = value_widget_callback(self, action, name, getvalue=getvalue)
-                action.changed.connect(f)
-
-            # If the field has callbacks, connect it to the newly generated widget.
-            for callback in fld.callbacks:
-                # funcname = callback.__name__
-                action.changed.connect(define_callback(self, callback))
+            getvalue = type(fld) is MagicField
+            f = value_widget_callback(self, action, name, getvalue=getvalue)
+            action.changed.connect(f)
 
         return action
 

--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -1102,7 +1102,7 @@ def _method_as_getter(self, getter: Callable):
 
 def _field_as_getter(bgui: BaseGui, fld: MagicField):
     """Called when a MagicField is used in Bound method."""
-    qualname = fld.parent_class.__qualname__
+    qualname = fld._parent_class.__qualname__
     if _LOCALS in qualname:
         qualname = qualname.split(_LOCALS)[-1]
     clsnames = qualname.split(".")
@@ -1120,7 +1120,7 @@ def _field_as_getter(bgui: BaseGui, fld: MagicField):
         for clsname in clsnames[i:]:
             ins = getattr(ins, clsname, ins)
 
-        # Now, ins is an instance of parent_class.
+        # Now, ins is an instance of parent class.
         # Extract correct widget from MagicField
         _field_widget = fld.get_widget(ins)
         if not hasattr(_field_widget, "value"):

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -23,7 +23,6 @@ from ._base import (
 )
 from .utils import (
     copy_class,
-    define_callback,
     format_error,
     set_context_menu,
 )
@@ -90,10 +89,6 @@ class ClassGuiBase(BaseGui):
                 getvalue = type(fld) is MagicField
                 f = value_widget_callback(self, widget, name, getvalue=getvalue)
                 widget.changed.connect(f)
-
-            for callback in fld.callbacks:
-                # funcname = callback.__name__
-                widget.changed.connect(define_callback(self, callback))
 
         elif fld.callbacks:
             warnings.warn(

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from inspect import signature
 from typing import Any, Callable, Sequence, TypeVar
 import warnings
 from qtpy.QtWidgets import QMenuBar, QWidget, QMainWindow, QBoxLayout, QDockWidget
@@ -138,9 +137,8 @@ class ClassGuiBase(BaseGui):
                     widget = self._create_widget_from_field(name, attr)
 
                 elif isinstance(attr, FunctionGui):
-                    widget = attr
-                    p0 = list(signature(attr).parameters)[0]
-                    getattr(widget, p0).bind(self)  # set self to the first argument
+                    widget = attr.copy()
+                    widget[0].bind(self)  # bind self to the first argument
 
                 else:
                     # convert class method into instance method

--- a/magicclass/_gui/utils.py
+++ b/magicclass/_gui/utils.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Callable, TYPE_CHECKING, TypeVar
+from typing import Any, TYPE_CHECKING, TypeVar
 from magicgui.widgets import FunctionGui, _protocols, _bases, Widget
 from magicgui.widgets._bases.value_widget import UNSET
 from magicgui.type_map import get_widget_class
@@ -13,36 +13,6 @@ if TYPE_CHECKING:
 
 def get_parameters(fgui: FunctionGui):
     return {k: v.default for k, v in fgui.__signature__.parameters.items()}
-
-
-def define_callback(self: BaseGui, callback: Callable):
-    """Define a callback function from a method."""
-    *_, clsname, funcname = callback.__qualname__.split(".")
-    mro = self.__class__.__mro__
-    for base in mro:
-        if base.__name__ == clsname:
-
-            def _callback():
-                with self.macro.blocked():
-                    getattr(base, funcname)(self)
-                return None
-
-            break
-    else:
-
-        def _callback():
-            # search for parent instances that have the same name.
-            current_self = self
-            while not (
-                hasattr(current_self, funcname)
-                and current_self.__class__.__name__ == clsname
-            ):
-                current_self = current_self.__magicclass_parent__
-            with self.macro.blocked():
-                getattr(current_self, funcname)()
-            return None
-
-    return _callback
 
 
 def set_context_menu(contextmenu: ContextMenuGui, parent: BaseGui) -> None:

--- a/magicclass/ext/vispy/_base.py
+++ b/magicclass/ext/vispy/_base.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+import numpy as np
 from vispy.visuals import Visual
+from vispy.scene import transforms
 
 
 class LayerItem:
@@ -6,8 +9,21 @@ class LayerItem:
 
     @property
     def visible(self) -> bool:
+        """Layer visibility."""
         return self._visual.visible
 
     @visible.setter
     def visible(self, v: bool) -> None:
         self._visual.visible = v
+
+    def _get_transform(self) -> transforms.MatrixTransform:
+        return self._visual.transform
+
+    def affine_transform(self, mtx: np.ndarray):
+        """Apply affine transformation to the layer."""
+        self._visual.transform = transforms.MatrixTransform(mtx)
+
+    @property
+    def translate(self) -> np.ndarray:
+        mtx = self._get_transform().matrix
+        return mtx[:3, 4]

--- a/magicclass/fields.py
+++ b/magicclass/fields.py
@@ -17,7 +17,7 @@ from enum import Enum
 from dataclasses import Field, MISSING
 from magicgui.type_map import get_widget_class
 from magicgui.widgets import create_widget
-from magicgui.widgets._bases import Widget, ValueWidget
+from magicgui.widgets._bases import Widget, ValueWidget, ContainerWidget
 from magicgui.widgets._bases.value_widget import UNSET
 
 from ._gui.mgui_ext import Action, WidgetAction
@@ -80,14 +80,14 @@ class MagicField(Field, Generic[_W, _V]):
 
         # MagicField has to remenber the first class that referred to itself so that it can
         # "know" the namespace it belongs to.
-        self.parent_class: type = None
+        self._parent_class: type | None = None
 
     def __repr__(self):
         return self.__class__.__name__.rstrip("Field") + super().__repr__()
 
     def __set_name__(self, owner: type, name: str) -> None:
         super().__set_name__(owner, name)
-        self.parent_class = owner
+        self._parent_class = owner
         if self.name is None:
             self.name = name
 
@@ -123,9 +123,12 @@ class MagicField(Field, Generic[_W, _V]):
             with self._resolve_choices(obj):
                 widget = self.to_widget()
                 self.guis[obj_id] = widget
-                # for callback in self.callbacks:
-                #     # funcname = callback.__name__
-                #     widget.changed.connect(define_callback(obj, callback))
+
+            # if isinstance(widget, (ValueWidget, ContainerWidget)):
+            #     from ._gui.utils import define_callback
+            #     for callback in self.callbacks:
+            #         # funcname = callback.__name__
+            #         widget.changed.connect(define_callback(obj, callback))
 
         return widget
 

--- a/magicclass/fields.py
+++ b/magicclass/fields.py
@@ -796,7 +796,7 @@ class FieldGroup(Container, HasFields):
         return wdt
 
     def connect(self, callback: Callable):
-        # self.changed.connect(callback)
+        # self.changed.connect(callback)  NOTE: the original container doesn't need signals!
         self._callbacks.append(callback)
         return callback
 

--- a/magicclass/fields.py
+++ b/magicclass/fields.py
@@ -85,6 +85,12 @@ class MagicField(Field, Generic[_W, _V]):
     def __repr__(self):
         return self.__class__.__name__.rstrip("Field") + super().__repr__()
 
+    def __set_name__(self, owner: type, name: str) -> None:
+        super().__set_name__(owner, name)
+        self.parent_class = owner
+        if self.name is None:
+            self.name = name
+
     def copy(self) -> MagicField:
         """Copy object."""
         return self.__class__(
@@ -111,15 +117,15 @@ class MagicField(Field, Generic[_W, _V]):
         by ``obj.field``.
         """
         obj_id = id(obj)
-        objtype = type(obj)
         if obj_id in self.guis.keys():
             widget = self.guis[obj_id]
         else:
             with self._resolve_choices(obj):
                 widget = self.to_widget()
                 self.guis[obj_id] = widget
-            if self.parent_class is None:
-                self.parent_class = objtype
+                # for callback in self.callbacks:
+                #     # funcname = callback.__name__
+                #     widget.changed.connect(define_callback(obj, callback))
 
         return widget
 
@@ -129,15 +135,12 @@ class MagicField(Field, Generic[_W, _V]):
         by ``obj.field``.
         """
         obj_id = id(obj)
-        objtype = type(obj)
         if obj_id in self.guis.keys():
             action = self.guis[obj_id]
         else:
             with self._resolve_choices(obj):
                 action = self.to_action()
                 self.guis[obj_id] = action
-            if self.parent_class is None:
-                self.parent_class = objtype
 
         return action
 

--- a/magicclass/fields.py
+++ b/magicclass/fields.py
@@ -792,6 +792,7 @@ class FieldGroup(Container, HasFields):
         wdt = self._containers.get(_id, None)
         if wdt is None:
             wdt = self.copy()
+            self._containers[_id] = wdt
         return wdt
 
     def connect(self, callback: Callable):

--- a/magicclass/widgets/plot.py
+++ b/magicclass/widgets/plot.py
@@ -10,6 +10,11 @@ from .utils import FreeWidget
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.lines import Line2D
+    from matplotlib.collections import PathCollection
+    from matplotlib.text import Text
+    from matplotlib.quiver import Quiver
+    from matplotlib.legend import Legend
     from numpy.typing import ArrayLike
 
 try:
@@ -84,12 +89,12 @@ class Figure(FreeWidget):
     interactive = enabled  # alias
 
     @_inject_mpl_docs
-    def clf(self):
+    def clf(self) -> None:
         self.figure.clf()
         self.draw()
 
     @_inject_mpl_docs
-    def cla(self):
+    def cla(self) -> None:
         self.ax.cla()
         self.draw()
 
@@ -108,7 +113,9 @@ class Figure(FreeWidget):
         return _ax
 
     @_inject_mpl_docs
-    def subplots(self, *args, **kwargs):
+    def subplots(
+        self, *args, **kwargs
+    ) -> tuple[Figure, Axes] | tuple[Figure, list[Axes]]:
         self.clf()
         fig = self.figure
         axs = fig.subplots(*args, **kwargs)
@@ -116,20 +123,20 @@ class Figure(FreeWidget):
         return fig, axs
 
     @_inject_mpl_docs
-    def savefig(self, *args, **kwargs):
+    def savefig(self, *args, **kwargs) -> None:
         return self.figure.savefig(*args, **kwargs)
 
     @_inject_mpl_docs
-    def plot(self, *args, **kwargs) -> Axes:
-        self.ax.plot(*args, **kwargs)
+    def plot(self, *args, **kwargs) -> list[Line2D]:
+        lines = self.ax.plot(*args, **kwargs)
         self.draw()
-        return self.ax
+        return lines
 
     @_inject_mpl_docs
-    def scatter(self, *args, **kwargs) -> Axes:
-        self.ax.scatter(*args, **kwargs)
+    def scatter(self, *args, **kwargs) -> PathCollection:
+        paths = self.ax.scatter(*args, **kwargs)
         self.draw()
-        return self.ax
+        return paths
 
     @_inject_mpl_docs
     def hist(
@@ -140,37 +147,37 @@ class Figure(FreeWidget):
         return out
 
     @_inject_mpl_docs
-    def text(self, *args, **kwargs):
-        self.ax.text(*args, **kwargs)
+    def text(self, *args, **kwargs) -> Text:
+        text = self.ax.text(*args, **kwargs)
         self.draw()
-        return self.ax
+        return text
 
     @_inject_mpl_docs
-    def quiver(self, *args, data=None, **kwargs):
-        self.ax.quiver(*args, data=data, **kwargs)
+    def quiver(self, *args, data=None, **kwargs) -> Quiver:
+        quiver = self.ax.quiver(*args, data=data, **kwargs)
         self.draw()
-        return self.ax
+        return quiver
 
     @_inject_mpl_docs
-    def axline(self, xy1, xy2=None, *, slope=None, **kwargs):
-        self.ax.axline(xy1, xy2=xy2, slope=slope, **kwargs)
+    def axline(self, xy1, xy2=None, *, slope=None, **kwargs) -> Line2D:
+        lines = self.ax.axline(xy1, xy2=xy2, slope=slope, **kwargs)
         self.draw()
-        return self.ax
+        return lines
 
     @_inject_mpl_docs
-    def axhline(self, y=0, xmin=0, xmax=1, **kwargs):
-        self.ax.axhline(y, xmin, xmax, **kwargs)
+    def axhline(self, y=0, xmin=0, xmax=1, **kwargs) -> Line2D:
+        lines = self.ax.axhline(y, xmin, xmax, **kwargs)
         self.draw()
-        return self.ax
+        return lines
 
     @_inject_mpl_docs
-    def axvline(self, x=0, ymin=0, ymax=1, **kwargs):
-        self.ax.axvline(x, ymin, ymax, **kwargs)
+    def axvline(self, x=0, ymin=0, ymax=1, **kwargs) -> Line2D:
+        lines = self.ax.axvline(x, ymin, ymax, **kwargs)
         self.draw()
-        return self.ax
+        return lines
 
     @_inject_mpl_docs
-    def xlim(self, *args, **kwargs):
+    def xlim(self, *args, **kwargs) -> tuple[float, float]:
         ax = self.ax
         if not args and not kwargs:
             return ax.get_xlim()
@@ -179,7 +186,7 @@ class Figure(FreeWidget):
         return ret
 
     @_inject_mpl_docs
-    def ylim(self, *args, **kwargs):
+    def ylim(self, *args, **kwargs) -> tuple[float, float]:
         ax = self.ax
         if not args and not kwargs:
             return ax.get_ylim()
@@ -194,31 +201,31 @@ class Figure(FreeWidget):
         return self.ax
 
     @_inject_mpl_docs
-    def legend(self, *args, **kwargs):
+    def legend(self, *args, **kwargs) -> Legend:
         leg = self.ax.legend(*args, **kwargs)
         self.draw()
         return leg
 
     @_inject_mpl_docs
-    def title(self, *args, **kwargs):
+    def title(self, *args, **kwargs) -> Text:
         title = self.ax.set_title(*args, **kwargs)
         self.draw()
         return title
 
     @_inject_mpl_docs
-    def xlabel(self, *args, **kwargs):
-        xlabel = self.ax.set_xlabel(*args, **kwargs)
+    def xlabel(self, *args, **kwargs) -> None:
+        self.ax.set_xlabel(*args, **kwargs)
         self.draw()
-        return xlabel
+        return None
 
     @_inject_mpl_docs
-    def ylabel(self, *args, **kwargs):
-        ylabel = self.ax.set_ylabel(*args, **kwargs)
+    def ylabel(self, *args, **kwargs) -> None:
+        self.ax.set_ylabel(*args, **kwargs)
         self.draw()
-        return ylabel
+        return None
 
     @_inject_mpl_docs
-    def xticks(self, ticks=None, labels=None, **kwargs):
+    def xticks(self, ticks=None, labels=None, **kwargs) -> tuple[ArrayLike, list[Text]]:
         if ticks is None:
             locs = self.ax.get_xticks()
             if labels is not None:
@@ -239,7 +246,7 @@ class Figure(FreeWidget):
         return locs, labels
 
     @_inject_mpl_docs
-    def yticks(self, ticks=None, labels=None, **kwargs):
+    def yticks(self, ticks=None, labels=None, **kwargs) -> tuple[ArrayLike, list[Text]]:
         if ticks is None:
             locs = self.ax.get_yticks()
             if labels is not None:
@@ -272,60 +279,63 @@ class Figure(FreeWidget):
         if on is None:
             on = not self.ax.get_frame_on()
         self.ax.set_frame_on(on)
+        return None
 
     @_inject_mpl_docs
-    def xscale(self, scale=None):
+    def xscale(self, scale=None) -> None:
         self.ax.set_xscale(scale)
         self.draw()
+        return None
 
     @_inject_mpl_docs
-    def yscale(self, scale=None):
+    def yscale(self, scale=None) -> None:
         self.ax.set_yscale(scale)
         self.draw()
+        return None
 
     @_inject_mpl_docs
-    def autoscale(self, enable=True, axis="both", tight=None):
+    def autoscale(self, enable=True, axis="both", tight=None) -> None:
         self.ax.autoscale(enable=enable, axis=axis, tight=tight)
         self.draw()
+        return None
 
 
 class SeabornFigure(Figure):
-    def swarmplot(self, **kwargs):
+    """A matplotlib figure canvas implemented with seaborn plot functions."""
+
+    def __init__(
+        self,
+        nrows: int = 1,
+        ncols: int = 1,
+        figsize: tuple[float, float] = (4.0, 3.0),
+        style=None,
+        **kwargs,
+    ):
+        super().__init__(**locals())
         import seaborn as sns
 
-        return sns.swarmplot(ax=self.ax, **kwargs)
+        self._seaborn = sns
+
+    def swarmplot(self, **kwargs):
+        return self._seaborn.swarmplot(ax=self.ax, **kwargs)
 
     def barplot(self, **kwargs):
-        import seaborn as sns
-
-        return sns.barplot(ax=self.ax, **kwargs)
+        return self._seaborn.barplot(ax=self.ax, **kwargs)
 
     def boxplot(self, **kwargs):
-        import seaborn as sns
-
-        return sns.boxplot(ax=self.ax, **kwargs)
+        return self._seaborn.boxplot(ax=self.ax, **kwargs)
 
     def boxenplot(self, **kwargs):
-        import seaborn as sns
-
-        return sns.boxenplot(ax=self.ax, **kwargs)
+        return self._seaborn.boxenplot(ax=self.ax, **kwargs)
 
     def violinplot(self, **kwargs):
-        import seaborn as sns
-
-        return sns.violinplot(ax=self.ax, **kwargs)
+        return self._seaborn.violinplot(ax=self.ax, **kwargs)
 
     def pairplot(self, **kwargs):
-        import seaborn as sns
-
-        return sns.pairplot(ax=self.ax, **kwargs)
+        return self._seaborn.pairplot(ax=self.ax, **kwargs)
 
     def barplot(self, **kwargs):
-        import seaborn as sns
-
-        return sns.barplot(ax=self.ax, **kwargs)
+        return self._seaborn.barplot(ax=self.ax, **kwargs)
 
     def pointplot(self, **kwargs):
-        import seaborn as sns
-
-        return sns.pointplot(ax=self.ax, **kwargs)
+        return self._seaborn.pointplot(ax=self.ax, **kwargs)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,12 @@
-from magicclass import magicclass, magicmenu, magictoolbar, field, vfield, set_design
+from magicclass import (
+    magicclass,
+    magicmenu,
+    magictoolbar,
+    field,
+    vfield,
+    FieldGroup,
+    set_design,
+)
 from magicclass.types import Optional
 from magicgui import widgets
 from typing import Tuple
@@ -358,3 +366,49 @@ def test_generic_and_annotated():
     assert w1[0].text == "XXX"
     assert w1[1].max == 10
     assert w2[1].widget_type == "TupleEdit"
+
+def test_field_in_non_gui():
+    """Test fields can be used in non-GUI classes."""
+    class A:
+        x = field(int)
+        y = vfield(str)
+
+        def __init__(self):
+            self._x_value = None
+            self._y_value = None
+
+        @x.connect
+        def _x(self):
+            self._x_value = self.x.value
+
+        @y.connect
+        def _y(self):
+            self._y_value = self.y
+
+    a = A()
+    assert a.x.widget_type == "SpinBox"
+    a.x.value = 1
+    assert a._x_value == 1
+    a.y = "xxx"
+    assert a._y_value == "xxx"
+
+def test_field_group():
+    from magicgui.widgets import Container
+
+    class Params(FieldGroup):
+        x = field(int)
+        y = vfield(str)
+
+    class A:
+        params = Params(layout="horizontal")
+
+    a0 = A()
+    assert isinstance(a0.params, Container)
+    assert a0.params.x.widget_type == "SpinBox"
+    assert a0.params.y == ""
+    a0.params.x.value = 10
+    a0.params.y = "t"
+
+    a1 = A()
+    assert a1.params.x.value == 0
+    assert a1.params.y == ""

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -414,6 +414,13 @@ def test_field_group():
     assert a1.params.x.value == 0
     assert a1.params.y == ""
 
+    @magicclass
+    class Main:
+        params = Params()
+
+    ui = Main()
+    assert ui.params is ui[0]
+
 def test_has_fields():
     class A(HasFields):
         x = vfield(int)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,6 +5,7 @@ from magicclass import (
     field,
     vfield,
     FieldGroup,
+    HasFields,
     set_design,
 )
 from magicclass.types import Optional
@@ -412,3 +413,28 @@ def test_field_group():
     a1 = A()
     assert a1.params.x.value == 0
     assert a1.params.y == ""
+
+def test_has_fields():
+    class A(HasFields):
+        x = vfield(int)
+        y = vfield(str)
+        @property
+        def value(self):
+            return self.x, self.y
+
+    a0 = A()
+    a1 = A()
+
+    # test repr works
+    repr(a0)
+    repr(a0.widgets)
+
+    a0.x = 10
+    a0.y = "abc"
+
+    assert (10, "abc") == a0.value
+    assert (0, "") == a1.value
+
+    c0 = a0.widgets.as_container()
+    assert c0["x"].value == a0.x
+    assert c0["y"].value == a0.y

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -73,3 +73,23 @@ def test_wraps():
     assert len(ui.macro) == 3
     assert str(ui.macro[-1]) == "ui.f2(a=20, b='x')"
     assert str(ui.macro[-2]) == "ui.f2(a=10, b='x')"
+
+# NOTE: need fix on magicgui side
+# def test_multi_gui():
+#     @magicclass
+#     class A:
+#         @magicgui
+#         def f(self, x: int):
+#             return id(self)
+
+#         @magicgui
+#         def g(self, x: float):
+#             return -id(self)
+
+#     ui0 = A()
+#     ui1 = A()
+#     assert ui0["f"] is not ui1["f"]
+#     assert ui0["g"] is not ui1["g"]
+#     assert ui0["f"](0) == -ui0["g"](0)
+#     assert ui1["f"](0) == -ui1["g"](0)
+#     assert ui0["f"](0) != ui1["f"](0)


### PR DESCRIPTION
This PR makes `MagicField` more flexible for general usage.

- `MagicField` can know be used independent of `magicclass`.
- Add `FieldGroup` for a collection of fields and convert them into a `magicgui.widgets.Container`.
- Add `HasFields` for general usage of a collection of fields. `HasFields` is useful especially when a class has several parameters and they can be monitored/changed via GUI, while the instance itself is not a GUI.