### PR TITLE
Fix `singledispatchmethod` with options "bind" or "choices"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Documentation is available [here](https://hanjinliu.github.io/magic-class/).
 - use pip
 
 ```
-pip install magic-class
+pip install magic-class -U
 ```
 
 - get latest version

--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -916,7 +916,7 @@ def _get_widget_name(widget: Widget):
     return widget.name
 
 
-def _create_gui_method(self: BaseGui, obj: MethodType):
+def _create_gui_method(self: BaseGui, obj: MethodType) -> Callable:
     func_sig = inspect.signature(obj)
     # Method type cannot set __signature__ attribute.
     @functools.wraps(obj)

--- a/magicclass/functools/_dispatch.py
+++ b/magicclass/functools/_dispatch.py
@@ -159,6 +159,10 @@ class singledispatchmethod(functools.singledispatchmethod):
 
 
 class MultiValueWidget(TabbedContainer):
+    """
+    A special tabbed container that can be used to represent a dispatched argument.
+    """
+
     def __init__(
         self,
         annotations: list[type],

--- a/magicclass/functools/_dispatch.py
+++ b/magicclass/functools/_dispatch.py
@@ -104,6 +104,9 @@ def singledispatch(func):
     return wrapper
 
 
+# BUG: if "bind" or "choices" options are set with a class method in the dispatched
+# functions, they are not called correctly. _gui/_base.py::_create_gui_method
+# needs modification.
 class singledispatchmethod(functools.singledispatchmethod):
     """
     Single dispatch method aware of GUI options in magic-class.


### PR DESCRIPTION
With currently implementation, `@singledispatchmethod` and `@set_options` with "bind" or "choices" method pointing at class methods are not compatible. `ComboBox` object is sent to `self`. 