### PR TITLE
Add matplotlib plot API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode/
 *.ipynb
-make_doc.bat
+rst/_build/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/magicclass/core.py
+++ b/magicclass/core.py
@@ -81,13 +81,11 @@ def magicclass(
     """
     Decorator that can convert a Python class into a widget.
 
-    .. code-block:: python
-
-        @magicclass
-        class C:
-            ...
-        ui = C()
-        ui.show()  # open GUI
+    >>> @magicclass
+    >>> class C:
+    >>>     ...
+    >>> ui = C()
+    >>> ui.show()  # open GUI
 
     Parameters
     ----------
@@ -661,15 +659,12 @@ class Parameters:
         """
         Convert parameter fields into a dictionary.
 
-        .. code-block:: python
+        >>> class params(Parameters):
+        >>>     i = 1
+        >>>     j = 2
 
-            class params(Parameters):
-                i = 1
-                j = 2
-
-            p = params()
-            p.as_dict() # {"i": 1, "j": 2}
-
+        >>> p = params()
+        >>> p.as_dict() # {"i": 1, "j": 2}
         """
         params = list(self.__signature__.parameters.keys())[1:]
         return {param: getattr(self, param) for param in params}

--- a/magicclass/plot_api.py
+++ b/magicclass/plot_api.py
@@ -1,0 +1,103 @@
+from .widgets import Figure
+
+CURRENT_WIDGET: Figure = None
+
+
+def figure():
+    global CURRENT_WIDGET
+    CURRENT_WIDGET = Figure()
+    return CURRENT_WIDGET.figure
+
+
+def subplot(*args):
+    return figure().subplot(*args)
+
+
+def gcf():
+    """Get current figure."""
+    return CURRENT_WIDGET.figure
+
+
+def gca():
+    """Get current axis."""
+    return CURRENT_WIDGET.axes[-1]
+
+
+def gcw():
+    """Get current widget."""
+    global CURRENT_WIDGET
+    if CURRENT_WIDGET is None:
+        CURRENT_WIDGET = Figure()
+    return CURRENT_WIDGET
+
+
+def plot(*args, **kwargs):
+    return gcw().plot(*args, **kwargs)
+
+
+def scatter(*args, **kwargs):
+    return gcw().scatter(*args, **kwargs)
+
+
+def hist(*args, **kwargs):
+    return gcw().hist(*args, **kwargs)
+
+
+def imshow(*args, **kwargs):
+    return gcw().imshow(*args, **kwargs)
+
+
+def show():
+    CURRENT_WIDGET.show()
+
+
+def close():
+    CURRENT_WIDGET.close()
+
+
+def quiver(*args, **kwargs):
+    return gcw().quiver(*args, **kwargs)
+
+
+def text(*args, **kwargs):
+    return gcw().text(*args, **kwargs)
+
+
+def axhline(*args, **kwargs):
+    return gcw().axhline(*args, **kwargs)
+
+
+def axvline(*args, **kwargs):
+    return gcw().axvline(*args, **kwargs)
+
+
+def axline(*args, **kwargs):
+    return gcw().axline(*args, **kwargs)
+
+
+def xlim(*args, **kwargs):
+    return gcw().xlim(*args, **kwargs)
+
+
+def ylim(*args, **kwargs):
+    return gcw().ylim(*args, **kwargs)
+
+
+def title(*args, **kwargs):
+    return gcw().title(*args, **kwargs)
+
+
+def xlabel(*args, **kwargs):
+    return gcw().xlabel(*args, **kwargs)
+
+
+def ylabel(*args, **kwargs):
+    return gcw().ylabel(*args, **kwargs)
+
+
+def xticks(*args, **kwargs):
+    return gcw().xticks(*args, **kwargs)
+
+
+def yticks(*args, **kwargs):
+    return gcw().yticks(*args, **kwargs)

--- a/magicclass/plot_api.py
+++ b/magicclass/plot_api.py
@@ -33,6 +33,32 @@ def subplot(*args):
     return figure().subplot(*args)
 
 
+@wraps(plt.subplots)
+def subplots(
+    nrows=1,
+    ncols=1,
+    *,
+    sharex=False,
+    sharey=False,
+    squeeze=True,
+    subplot_kw=None,
+    gridspec_kw=None,
+    **fig_kw,
+):
+    fig = figure(**fig_kw)
+    fig.clf()
+    axs = fig.subplots(
+        nrows=nrows,
+        ncols=ncols,
+        sharex=sharex,
+        sharey=sharey,
+        squeeze=squeeze,
+        subplot_kw=subplot_kw,
+        gridspec_kw=gridspec_kw,
+    )
+    return fig, axs
+
+
 @wraps(plt.gcf)
 def gcf():
     """Get current figure."""
@@ -191,3 +217,8 @@ def autoscale(*args, **kwargs):
 @wraps(plt.grid)
 def grid(*args, **kwargs):
     return gcw().grid(*args, **kwargs)
+
+
+def draw():
+    """Draw current figure widget."""
+    return gcw().draw()

--- a/magicclass/plot_api.py
+++ b/magicclass/plot_api.py
@@ -1,29 +1,51 @@
+"""
+Provide a matplotlib-like interface to plot data in a Qt widget.
+Import this submodule
+
+>>> import magicclass.plot_api as plt
+
+and it's ready to use like matplotlib.
+
+>>> plt.plot(...)
+>>> plt.title(...)
+>>> plt.show()
+
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+import matplotlib.pyplot as plt
 from .widgets import Figure
 
 CURRENT_WIDGET: Figure = None
 
 
-def figure():
+@wraps(plt.figure)
+def figure(*args, **kwargs):
     global CURRENT_WIDGET
     CURRENT_WIDGET = Figure()
     return CURRENT_WIDGET.figure
 
 
+@wraps(plt.subplot)
 def subplot(*args):
     return figure().subplot(*args)
 
 
+@wraps(plt.gcf)
 def gcf():
     """Get current figure."""
     return CURRENT_WIDGET.figure
 
 
+@wraps(plt.gca)
 def gca():
     """Get current axis."""
     return CURRENT_WIDGET.axes[-1]
 
 
-def gcw():
+def gcw() -> Figure:
     """Get current widget."""
     global CURRENT_WIDGET
     if CURRENT_WIDGET is None:
@@ -31,73 +53,141 @@ def gcw():
     return CURRENT_WIDGET
 
 
+@wraps(plt.cla)
+def cla():
+    return gcw().cla()
+
+
+@wraps(plt.plot)
 def plot(*args, **kwargs):
     return gcw().plot(*args, **kwargs)
 
 
+@wraps(plt.scatter)
 def scatter(*args, **kwargs):
     return gcw().scatter(*args, **kwargs)
 
 
+@wraps(plt.hist)
 def hist(*args, **kwargs):
     return gcw().hist(*args, **kwargs)
 
 
+@wraps(plt.bar)
+def bar(*args, **kwargs):
+    return gcw().bar(*args, **kwargs)
+
+
+@wraps(plt.imshow)
 def imshow(*args, **kwargs):
     return gcw().imshow(*args, **kwargs)
 
 
 def show():
-    CURRENT_WIDGET.show()
+    """Show current figure widget."""
+    return gcw().show()
 
 
 def close():
-    CURRENT_WIDGET.close()
+    """Close current figure widget"""
+    return gcw().close()
 
 
+@wraps(plt.quiver)
 def quiver(*args, **kwargs):
     return gcw().quiver(*args, **kwargs)
 
 
+@wraps(plt.text)
 def text(*args, **kwargs):
     return gcw().text(*args, **kwargs)
 
 
+@wraps(plt.axhline)
 def axhline(*args, **kwargs):
     return gcw().axhline(*args, **kwargs)
 
 
+@wraps(plt.axvline)
 def axvline(*args, **kwargs):
     return gcw().axvline(*args, **kwargs)
 
 
+@wraps(plt.axline)
 def axline(*args, **kwargs):
     return gcw().axline(*args, **kwargs)
 
 
+@wraps(plt.xlim)
 def xlim(*args, **kwargs):
     return gcw().xlim(*args, **kwargs)
 
 
+@wraps(plt.ylim)
 def ylim(*args, **kwargs):
     return gcw().ylim(*args, **kwargs)
 
 
+@wraps(plt.title)
 def title(*args, **kwargs):
     return gcw().title(*args, **kwargs)
 
 
+@wraps(plt.xlabel)
 def xlabel(*args, **kwargs):
     return gcw().xlabel(*args, **kwargs)
 
 
+@wraps(plt.ylabel)
 def ylabel(*args, **kwargs):
     return gcw().ylabel(*args, **kwargs)
 
 
+@wraps(plt.xticks)
 def xticks(*args, **kwargs):
     return gcw().xticks(*args, **kwargs)
 
 
+@wraps(plt.yticks)
 def yticks(*args, **kwargs):
     return gcw().yticks(*args, **kwargs)
+
+
+@wraps(plt.legend)
+def legend(*args, **kwargs):
+    return gcw().legend(*args, **kwargs)
+
+
+@wraps(plt.twinx)
+def twinx(*args, **kwargs):
+    return gcw().twinx(*args, **kwargs)
+
+
+@wraps(plt.twiny)
+def twiny(*args, **kwargs):
+    return gcw().twiny(*args, **kwargs)
+
+
+@wraps(plt.box)
+def box(*args, **kwargs):
+    return gcw().box(*args, **kwargs)
+
+
+@wraps(plt.xscale)
+def xscale(*args, **kwargs):
+    return gcw().xscale(*args, **kwargs)
+
+
+@wraps(plt.yscale)
+def yscale(*args, **kwargs):
+    return gcw().yscale(*args, **kwargs)
+
+
+@wraps(plt.autoscale)
+def autoscale(*args, **kwargs):
+    return gcw().autoscale(*args, **kwargs)
+
+
+@wraps(plt.grid)
+def grid(*args, **kwargs):
+    return gcw().grid(*args, **kwargs)

--- a/magicclass/types.py
+++ b/magicclass/types.py
@@ -103,7 +103,7 @@ def bound(obj: type[_W]) -> type: ...
 
 
 def bound(obj):
-    """Function version of Bound[...]."""
+    """Function version of ``Bound[...]``."""
     # NOTE: This could be more useful than Bound??
     if callable(obj):
         outtype = obj.__annotations__.get("return", Any)
@@ -142,13 +142,11 @@ class _BoundAlias(type):
 
     For instance, if type annotation is added like this
 
-    .. code-block:: python
+    >>> def _get_int(self, _=None) -> int:
+    >>>     return 0
 
-        def _get_int(self, _=None) -> int:
-            return 0
-
-        def func(self, x: Bound[_get_int]):
-            # do something
+    >>> def func(self, x: Bound[_get_int]):
+    >>>     # do something
 
     ``x`` will be considered to be ``Bound`` type otherwise.
     """
@@ -179,15 +177,12 @@ class Bound(metaclass=_BoundAlias):
     """
     Make Annotated type from a MagicField or a method, such as:
 
-    .. code-block:: python
-
-        from magicclass import magicclass, field
-
-        @magicclass
-        class MyClass:
-            i = field(int)
-            def func(self, v: Bound[i]):
-                ...
+    >>> from magicclass import magicclass, field
+    >>> @magicclass
+    >>> class MyClass:
+    >>>     i = field(int)
+    >>>     def func(self, v: Bound[i]):
+    >>>         ...
 
     ``Bound[value]`` is identical to ``Annotated[Any, {"bind": value}]``.
     """
@@ -267,14 +262,11 @@ class OneOf(metaclass=_OneOfAlias):
     """
     Make Annotated type from a method, such as:
 
-    .. code-block:: python
-
-        from magicclass import magicclass
-
-        @magicclass
-        class MyClass:
-            def func(self, v: OneOf[(1, 2, 3)]):
-                ...
+    >>> from magicclass import magicclass
+    >>> @magicclass
+    >>> class MyClass:
+    >>>     def func(self, v: OneOf[(1, 2, 3)]):
+    >>>         ...
 
     ``OneOf[value]`` is identical to ``Annotated[Any, {"choices": value}]``.
     """
@@ -293,9 +285,7 @@ Choices = OneOf  # alias
 
 
 class _SomeOfAlias(type):
-    """
-    This metaclass is necessary for ``mypy`` to reveal type.
-    """
+    """This metaclass is necessary for ``mypy`` to reveal type."""
 
     @overload
     def __getitem__(
@@ -338,14 +328,12 @@ class SomeOf(metaclass=_SomeOfAlias):
     """
     Make Annotated type from a method, such as:
 
-    .. code-block:: python
+    >>> from magicclass import magicclass
 
-        from magicclass import magicclass
-
-        @magicclass
-        class MyClass:
-            def func(self, v: Choices[(1, 2, 3)]):
-                ...
+    >>> @magicclass
+    >>> class MyClass:
+    >>>     def func(self, v: Choices[(1, 2, 3)]):
+    >>>         ...
 
     ``Choices[value]`` is identical to ``Annotated[Any, {"choices": value}]``.
     """
@@ -400,20 +388,17 @@ class Optional(metaclass=_OptionalAlias):
     Arguments annotated with ``Optional[int]`` will create a
     ``OptionalWidget`` with a ``SpinBox`` as an inner widget.
 
-    Examples
-    --------
+    >>> from magicclass import magicclass, set_options
+    >>> from magicclass.types import Optional
 
-    from magicclass import magicclass, set_options
-    from magicclass.types import Optional
+    >>> @magicclass
+    >>> class A:
+    >>>     @set_options(a={"options": {"min": -1}})
+    >>>     def f(self, a: Optional[int]):
+    >>>         print(a)
 
-    @magicclass
-    class A:
-        @set_options(a={"options": {"min": -1}})
-        def f(self, a: Optional[int]):
-            print(a)
-
-    ui = A()
-    ui.show()
+    >>> ui = A()
+    >>> ui.show()
     """
 
     def __new__(cls, *args, **kwargs):
@@ -445,19 +430,16 @@ class Union(metaclass=_UnionAlias):
     Arguments annotated with ``Union[int, str]`` will create a
     ``UnionWidget`` with a ``SpinBox`` and a ``LineEdit`` as inner widgets.
 
-    Examples
-    --------
+    >>> from magicclass import magicclass
+    >>> from magicclass.types import Union
 
-    from magicclass import magicclass
-    from magicclass.types import Union
+    >>> @magicclass
+    >>> class A:
+    >>>     def f(self, a: Union[int, str]):
+    >>>         print(a)
 
-    @magicclass
-    class A:
-        def f(self, a: Union[int, str]):
-            print(a)
-
-    ui = A()
-    ui.show()
+    >>> ui = A()
+    >>> ui.show()
     """
 
     def __new__(cls, *args, **kwargs):

--- a/magicclass/widgets/logger.py
+++ b/magicclass/widgets/logger.py
@@ -14,7 +14,7 @@ from ..utils import rst_to_html
 
 if TYPE_CHECKING:
     import numpy as np
-    from matplotlib.figure import Figure
+    from matplotlib.figure import Figure as mpl_Figure
 
 # See https://stackoverflow.com/questions/28655198/best-way-to-display-logs-in-pyqt
 
@@ -339,7 +339,7 @@ class Logger(Widget, logging.Handler):
         self.native.appendImage(image)
         return None
 
-    def print_figure(self, fig: Figure) -> None:
+    def print_figure(self, fig: mpl_Figure) -> None:
         """Print matplotlib Figure object like inline plot."""
         import numpy as np
 

--- a/magicclass/widgets/plot.py
+++ b/magicclass/widgets/plot.py
@@ -227,6 +227,12 @@ class Figure(FreeWidget):
         return out
 
     @_inject_mpl_docs
+    def bar(self, *args, **kwargs) -> None:
+        bars = self.ax.bar(*args, **kwargs)
+        self.draw()
+        return bars
+
+    @_inject_mpl_docs
     def text(self, *args, **kwargs) -> Text:
         text = self.ax.text(*args, **kwargs)
         self.draw()
@@ -353,6 +359,12 @@ class Figure(FreeWidget):
     @_inject_mpl_docs
     def twiny(self) -> Axes:
         return self.ax.twiny()
+
+    @_inject_mpl_docs
+    def grid(self, *args, **kwargs) -> None:
+        self.ax.grid(*args, **kwargs)
+        self.draw()
+        return None
 
     @_inject_mpl_docs
     def box(self, on=None) -> None:

--- a/rst/main/visualization/matplotlib.rst
+++ b/rst/main/visualization/matplotlib.rst
@@ -85,3 +85,30 @@ you'll have to call ``draw`` method to update the figure.
     @magicclass
     class Main:
         plt = field(Figure, options={"nrows": 1, "ncols": 2})
+
+Plot API
+--------
+
+For the simplest usage, you can use ``plot_api`` submodule. Its API is almost
+identical to those in ``matplotlib.pyplot``.
+
+.. code-block:: python
+
+    # instead of import matplotlib.pyplot as plt
+    import magicclass.plot_api as plt
+
+    plt.figure()
+    plt.plot([0, 1, 2, 3], [4, 2, 3, 1], color="red")
+    plt.show()
+
+The current figure widget is available with ``gcw()`` function. It returns the
+``Figure`` widget, which is a ``magicgui`` widget.
+
+.. code-block:: python
+
+    # add figure to a widget.
+    from magicgui.widgets import Container
+
+    fig = plt.gcw()
+    cnt = Container(widgets=[fig])
+    cnt.show()


### PR DESCRIPTION
This PR implements simple plot API for matplotlib figure widget.

This will work

```python
import magicclass.plot_api as plt
plt.plot(np.random.random(100)
plt.show()
```

and the widget is available by calling `gcw` (get current widget).

```python
from magicgui.widgets import Container

figure_widget = plt.gcw()
cnt = Container()
cnt.append(figure_widget)
```