### PR TITLE
New preview architecture

### DIFF
--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -20,6 +20,7 @@ from .wrappers import (
     confirm,
     nogui,
     mark_preview,
+    impl_preview,
     mark_on_calling,
     mark_on_called,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "confirm",
     "nogui",
     "mark_preview",
+    "impl_preview",
     "mark_on_calling",
     "mark_on_called",
     "field",

--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -1013,8 +1013,10 @@ def _build_mgui(widget_: Action | PushButtonPlus, func: Callable, parent: BaseGu
         )
         preview = opt.get("preview", None)
         if preview is not None:
-            btn_text, previewer = preview
-            mgui.append_preview(previewer.__get__(parent), btn_text)
+            btn_text, is_auto_call, previewer = preview
+            mgui.append_preview(
+                previewer.__get__(parent), btn_text, auto_call=is_auto_call
+            )
 
     except Exception as e:
         msg = (

--- a/magicclass/_gui/_function_gui.py
+++ b/magicclass/_gui/_function_gui.py
@@ -257,10 +257,7 @@ def _append_auto_call_preview(self: FunctionGui, f: Callable, text: str = "Previ
             )
 
         self.calling.connect(context.exit)
-
-        @self.called.connect
-        def _disable_auto_call():
-            cbox.value = False
+        self.called.connect_setattr(cbox, "value", False)  # must disable auto-call!
 
     return f
 

--- a/magicclass/_gui/_function_gui.py
+++ b/magicclass/_gui/_function_gui.py
@@ -257,7 +257,10 @@ def _append_auto_call_preview(self: FunctionGui, f: Callable, text: str = "Previ
             )
 
         self.calling.connect(context.exit)
-        self.called.connect_setattr(cbox, "value", False)  # must disable auto-call!
+
+        @self.called.connect
+        def _disable_auto_call():
+            cbox.value = False
 
     return f
 

--- a/magicclass/logging/core.py
+++ b/magicclass/logging/core.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 from functools import wraps
 from ..widgets import Logger

--- a/magicclass/wrappers.py
+++ b/magicclass/wrappers.py
@@ -288,7 +288,22 @@ def nogui(method: F) -> F:
     return method
 
 
-def mark_preview(function: Callable, text: str = "Preview") -> Callable[[F], F]:
+if TYPE_CHECKING:
+    from typing import Protocol
+
+    class PreviewFunction(Protocol):
+        def __call__(self, *args, **kwargs):
+            ...
+
+        def during_preview(self, f: F) -> F:
+            ...
+
+
+def mark_preview(
+    function: Callable | None = None,
+    text: str = "Preview",
+    auto_call: bool = False,
+) -> Callable[[Callable], PreviewFunction]:
     """
     Define a preview of a function.
 
@@ -310,66 +325,91 @@ def mark_preview(function: Callable, text: str = "Preview") -> Callable[[F], F]:
 
     Parameters
     ----------
-    function : callable
-        To which function previewer will be defined.
+    function : callable, optional
+        To which function previewer will be defined. If not provided, the to-be-
+        decorated function itself will be used as the preview function.
     text : str, optional
-        Text of preview button.
+        Text of the preview button or checkbox.
+    auto_call : bool, default is False
+        Whether the preview function will be auto-called. If true, a check box will
+        appear above the call button, and the preview function is auto-called during
+        it is checked.
     """
+    mark_self = False
 
-    def _wrapper(preview: F) -> F:
-        sig_preview = inspect.signature(preview)
-        sig_func = inspect.signature(function)
-        params_preview = sig_preview.parameters
-        params_func = sig_func.parameters
+    def _outer_wrapper(target_func):
+        def _wrapper(preview: F) -> F:
+            sig_preview = inspect.signature(preview)
+            sig_func = inspect.signature(target_func)
+            params_preview = sig_preview.parameters
+            params_func = sig_func.parameters
 
-        less = len(params_func) - len(params_preview)
-        if less == 0:
-            if params_preview.keys() != params_func.keys():
+            less = len(params_func) - len(params_preview)
+            if less == 0:
+                if params_preview.keys() != params_func.keys():
+                    raise TypeError(
+                        f"Arguments mismatch between {sig_preview!r} and {sig_func!r}."
+                    )
+                # If argument names are identical, input arguments don't have to be filtered.
+                _filter = lambda a: a
+
+            elif less > 0:
+                idx: list[int] = []
+                for i, param in enumerate(params_func.keys()):
+                    if param in params_preview:
+                        idx.append(i)
+                # If argument names are not identical, input arguments have to be filtered so
+                # that arguments match the inputs.
+                _filter = lambda _args: (a for i, a in enumerate(_args) if i in idx)
+
+            else:
                 raise TypeError(
-                    f"Arguments mismatch between {sig_preview!r} and {sig_func!r}."
+                    f"Number of arguments of preview function {preview!r} must be equal"
+                    f"or smaller than that of running function {target_func!r}."
                 )
-            # If argument names are identical, input arguments don't have to be filtered.
-            _filter = lambda a: a
 
-        elif less > 0:
-            idx: list[int] = []
-            for i, param in enumerate(params_func.keys()):
-                if param in params_preview:
-                    idx.append(i)
-            # If argument names are not identical, input arguments have to be filtered so
-            # that arguments match the inputs.
-            _filter = lambda _args: (a for i, a in enumerate(_args) if i in idx)
+            def _preview(*args):
+                # find proper parent instance in the case of classes being nested
+                from ._gui import BaseGui
 
-        else:
-            raise TypeError(
-                f"Number of arguments of preview function {preview!r} must be equal"
-                f"or smaller than that of running function {function!r}."
+                if len(args) > 0 and isinstance(args[0], BaseGui):
+                    ins = args[0]
+                    prev_ns = preview.__qualname__.split(".")[-2]
+                    while ins.__class__.__name__ != prev_ns:
+                        ins = ins.__magicclass_parent__
+                    args = (ins,) + args[1:]
+                # filter input arguments
+                return preview(*_filter(args))
+
+            _preview.__wrapped__ = preview
+            _preview.__name__ = getattr(preview, "__name__", "_preview")
+            _preview.__qualname__ = getattr(preview, "__qualname__", "")
+
+            if not isinstance(target_func, FunctionGui):
+                upgrade_signature(
+                    target_func,
+                    additional_options={"preview": (text, auto_call, _preview)},
+                )
+            else:
+                from ._gui._function_gui import append_preview
+
+                append_preview(target_func, _preview, text=text, auto_call=auto_call)
+
+            # add method
+            preview.during_preview = lambda fc: setattr(
+                _preview, "_preview_context", fc
             )
+            return preview
 
-        def _preview(*args):
-            # find proper parent instance in the case of classes being nested
-            from ._gui import BaseGui
+        if mark_self:
+            return _wrapper(target_func)
+        return _wrapper
 
-            if len(args) > 0 and isinstance(args[0], BaseGui):
-                ins = args[0]
-                prev_ns = preview.__qualname__.split(".")[-2]
-                while ins.__class__.__name__ != prev_ns:
-                    ins = ins.__magicclass_parent__
-                args = (ins,) + args[1:]
-            # filter input arguments
-            return preview(*_filter(args))
-
-        if not isinstance(function, FunctionGui):
-            upgrade_signature(
-                function, additional_options={"preview": (text, _preview)}
-            )
-        else:
-            from ._gui._function_gui import append_preview
-
-            append_preview(function, _preview, text=text)
-        return preview
-
-    return _wrapper
+    if function is not None:
+        return _outer_wrapper(function)
+    else:
+        mark_self = True
+        return _outer_wrapper
 
 
 _Fn = TypeVar("_Fn", bound=Callable[[FunctionGui], Any])

--- a/magicclass/wrappers.py
+++ b/magicclass/wrappers.py
@@ -381,8 +381,11 @@ def impl_preview(
                     while ins.__class__.__name__ != prev_ns:
                         ins = ins.__magicclass_parent__
                     args = (ins,) + args[1:]
-                # filter input arguments
-                return preview(*_filter(args))
+
+                with ins.macro.blocked():
+                    # filter input arguments
+                    out = preview(*_filter(args))
+                return out
 
             _preview.__wrapped__ = preview
             _preview.__name__ = getattr(preview, "__name__", "_preview")

--- a/magicclass/wrappers.py
+++ b/magicclass/wrappers.py
@@ -298,43 +298,33 @@ if TYPE_CHECKING:
         def __call__(self, *args, **kwargs):
             ...
 
-        def set_preview(self, f: F) -> F:
-            """Set `f` as preview function."""
-
         def during_preview(self, f: F) -> F:
-            """Set `f` as the context manager during preview."""
+            """Wrapped function will be used as a context manager during preview."""
 
 
 def impl_preview(
     function: Callable | None = None,
     text: str = "Preview",
     auto_call: bool = False,
-):
+) -> Callable[[Callable], PreviewFunction]:
     """
-    Implement a preview to a function.
+    Define a preview of a function.
 
     This decorator is useful for advanced magicgui creation. A "Preview" button
-    (if `auto_call=False`) or checkbox (if `auto_call=True`) will be added to
-    the widget. It also adds `set_preview` and `during_preview` attributes to
-    the function.
+    appears in the bottom of the widget built from the input function and the
+    decorated function will be called with the same arguments.
+    Following example shows how to define a previewer that prints the content of
+    the selected file.
 
     .. code-block:: python
 
-        @impl_preview
         def func(self, path: Path):
             ...
 
         @impl_preview(func)
         def _func_prev(self, path: Path):
-            # do something as a preview. If `set_preview` is not set, the original
-            # function `func` itself will be used as a preview function.
-
-        @func.during_preview
-        def _func_during_prev(self, path: Path):
-            # do something before preview
-            yield
-            # do something after preview
-
+            with open(path, mode="r") as f:
+                print(f.read())
 
     Parameters
     ----------
@@ -348,10 +338,40 @@ def impl_preview(
         appear above the call button, and the preview function is auto-called during
         it is checked.
     """
+    mark_self = False
 
-    def _outer_wrapper(target_func: Callable) -> PreviewFunction:
-        def _impl_arg_filter(preview: F, _filter=lambda x: x) -> F:
-            def func(*args):
+    def _outer_wrapper(target_func):
+        def _wrapper(preview: F) -> F:
+            sig_preview = inspect.signature(preview)
+            sig_func = inspect.signature(target_func)
+            params_preview = sig_preview.parameters
+            params_func = sig_func.parameters
+
+            less = len(params_func) - len(params_preview)
+            if less == 0:
+                if params_preview.keys() != params_func.keys():
+                    raise TypeError(
+                        f"Arguments mismatch between {sig_preview!r} and {sig_func!r}."
+                    )
+                # If argument names are identical, input arguments don't have to be filtered.
+                _filter = lambda a: a
+
+            elif less > 0:
+                idx: list[int] = []
+                for i, param in enumerate(params_func.keys()):
+                    if param in params_preview:
+                        idx.append(i)
+                # If argument names are not identical, input arguments have to be filtered so
+                # that arguments match the inputs.
+                _filter = lambda _args: (a for i, a in enumerate(_args) if i in idx)
+
+            else:
+                raise TypeError(
+                    f"Number of arguments of preview function {preview!r} must be equal"
+                    f"or smaller than that of running function {target_func!r}."
+                )
+
+            def _preview(*args):
                 # find proper parent instance in the case of classes being nested
                 from ._gui import BaseGui
 
@@ -364,86 +384,35 @@ def impl_preview(
                 # filter input arguments
                 return preview(*_filter(args))
 
-            func.__name__ = getattr(preview, "__name__", "")
-            func.__qualname__ = getattr(preview, "__qualname__", "")
-
-            return func
-
-        # Create a argument filter for preview or context manager function in the case of
-        # arguments not being the same as the original function.
-        sig_tgt = inspect.signature(target_func)
-        params_tgt = sig_tgt.parameters
-
-        def _get_arg_filter(fn: Callable) -> Callable:
-            sig_fn = inspect.signature(fn)
-            params_fn = sig_fn.parameters
-
-            less = len(params_tgt) - len(params_fn)
-            if less == 0:
-                if params_fn.keys() != params_tgt.keys():
-                    raise TypeError(
-                        f"Arguments mismatch between {sig_fn!r} and {sig_tgt!r}."
-                    )
-                # If argument names are identical, input arguments don't have to be filtered.
-                _filter = lambda a: a
-
-            elif less > 0:
-                idx: list[int] = []
-                for i, param in enumerate(params_tgt.keys()):
-                    if param in params_fn:
-                        idx.append(i)
-                # If argument names are not identical, input arguments have to be filtered so
-                # that arguments match the inputs.
-                _filter = lambda _args: (a for i, a in enumerate(_args) if i in idx)
-
-            else:
-                raise TypeError(
-                    f"Number of arguments of function {fn!r} must be equal"
-                    f"or smaller than that of running function {target_func!r}."
-                )
-            return _filter
-
-        def _set_preview(preview: F) -> F:
-            _filter = _get_arg_filter(preview)
-            _preview = _impl_arg_filter(preview, _filter)
+            _preview.__wrapped__ = preview
+            _preview.__name__ = getattr(preview, "__name__", "_preview")
+            _preview.__qualname__ = getattr(preview, "__qualname__", "")
 
             if not isinstance(target_func, FunctionGui):
-                if old_setting := get_additional_option(target_func, "preview", None):
-                    prev_func = old_setting[2]
-                    if cnt := getattr(prev_func, "_preview_context", None):
-                        _preview._preview_context = cnt
                 upgrade_signature(
                     target_func,
                     additional_options={"preview": (text, auto_call, _preview)},
                 )
             else:
-                raise NotImplementedError
+                from ._gui._function_gui import append_preview
+
+                append_preview(target_func, _preview, text=text, auto_call=auto_call)
+
+            # add method
+            preview.during_preview = lambda fc: setattr(
+                _preview, "_preview_context", fc
+            )
             return preview
 
-        def _during_preview(during: F) -> F:
-            _filter = _get_arg_filter(during)
-            _during = _impl_arg_filter(during, _filter)
+        if mark_self:
+            return _wrapper(target_func)
+        return _wrapper
 
-            if not isinstance(target_func, FunctionGui):
-                _prev_func = get_additional_option(target_func, "preview")[2]
-                _prev_func._preview_context = _during
-            else:
-                raise NotImplementedError
-            return during
-
-        _target_func: PreviewFunction = target_func  # type: ignore
-
-        # add method
-        _target_func.set_preview = _set_preview
-        _target_func.during_preview = _during_preview
-
-        # Set the original function as the preview by default (imagine previewing the
-        # result of Gaussian filter before actually running it).
-        _set_preview(_target_func)
-
-        return target_func
-
-    return _outer_wrapper if function is None else _outer_wrapper(function)
+    if function is not None:
+        return _outer_wrapper(function)
+    else:
+        mark_self = True
+        return _outer_wrapper
 
 
 mark_preview = impl_preview

--- a/magicclass/wrappers.py
+++ b/magicclass/wrappers.py
@@ -292,14 +292,17 @@ if TYPE_CHECKING:
     from typing import Protocol
 
     class PreviewFunction(Protocol):
+        __name__: str
+        __qualname__: str
+
         def __call__(self, *args, **kwargs):
             ...
 
         def during_preview(self, f: F) -> F:
-            ...
+            """Wrapped function will be used as a context manager during preview."""
 
 
-def mark_preview(
+def impl_preview(
     function: Callable | None = None,
     text: str = "Preview",
     auto_call: bool = False,
@@ -318,7 +321,7 @@ def mark_preview(
         def func(self, path: Path):
             ...
 
-        @mark_preview(func)
+        @impl_preview(func)
         def _func_prev(self, path: Path):
             with open(path, mode="r") as f:
                 print(f.read())
@@ -411,6 +414,8 @@ def mark_preview(
         mark_self = True
         return _outer_wrapper
 
+
+mark_preview = impl_preview
 
 _Fn = TypeVar("_Fn", bound=Callable[[FunctionGui], Any])
 

--- a/rst/main/use_preview.rst
+++ b/rst/main/use_preview.rst
@@ -3,9 +3,14 @@ Add Preview Functionalities
 ===========================
 
 It is a very usual case when you want to preview something before actually running a
-function. Suppose in your GUI you implemented a function that can load a csv file and
-summarize its contents, you may want to open the csv file and see if you chose the
-correct file.
+function.
+
+1. Suppose in your GUI you implemented a function that can load a csv file and
+   summarize its contents, you may want to open the csv file and see if you chose the
+   correct file.
+2. Suppose you want to process a dataset in-place, you may want to add a "preview"
+   checkbox so that you can search for the proper parameters (imagine Gaussian filter
+   function in other softwares).
 
 The preview functionality is, however, unexpectedly hard to be implemented in ``magicgui``
 or ``magic-class``.
@@ -13,18 +18,20 @@ or ``magic-class``.
 - If they are implemented in separate buttons, say in button "summarize csv" and
   "preview csv", users have to synchronize all the input arguments between these
   two widgets.
-- If they are implemented in a same button, you have to add an additional button in the
+- If they are implemented in a same widget, you have to add an additional button in the
   bottom of the ``FunctionGui``. This is not simple and hard to maintain.
+- In the case of 2, you'll have to properly connect signals such as "turn on preview",
+  "turn off preview" and "restore the original state", which is massive.
 
-In ``magic-class``, ``mark_preview`` decorator is very useful for this purpose. You can
+In ``magic-class``, ``impl_preview`` decorator is very useful for this purpose. You can
 define a preview function and directly integrate it into another function easily.
 
-Basic Usage
------------
+1. Preview a File
+=================
 
 .. code-block:: python
 
-    @mark_preview(f)
+    @impl_preview(f)
     def _f_prev(self, xxx):
         ...
 
@@ -37,7 +44,7 @@ created by ``f``, as a preview button above the call button.
     from pathlib import Path
     import pandas as pd
     from magicgui.widgets import Table  # for preview
-    from magicclass import magicclass, mark_preview
+    from magicclass import magicclass, impl_preview
 
     @magicclass
     class A:
@@ -45,7 +52,7 @@ created by ``f``, as a preview button above the call button.
             df = pd.read_csv(path)
             print(df.agg([np.mean, np.std]))  # print summary
 
-        @mark_preview(summarize_csv)
+        @impl_preview(summarize_csv)
         def _preview_csv(self, path):
             df = pd.read_csv(path)
             Table(value=df).show()  # open table widget as the preview
@@ -63,7 +70,7 @@ like ``calc_something(df, param)``, the ``param`` in not needed for preview.
             result = calc_something(df, param)
             print(result)
 
-        @mark_preview(calc_csv)
+        @impl_preview(calc_csv)
         def _preview_csv(self, path):  # "param" is not needed here
             df = pd.read_csv(path)
             Table(value=df).show()
@@ -88,9 +95,138 @@ the text of preview button using ``text=...`` argument.
             df = pd.read_csv(path)
             df.plot()
 
-        @mark_preview(summarize_csv)
-        @mark_preview(calc_csv)
-        @mark_preview(plot_csv, text="preview CSV")
+        @impl_preview(summarize_csv)
+        @impl_preview(calc_csv)
+        @impl_preview(plot_csv, text="preview CSV")
         def _preview_csv(self, path):  # "param" is not needed here
             df = pd.read_csv(path)
             Table(value=df).show()
+
+2. Prerun a Function
+====================
+
+This is essentially same as 1, except that the preview function will update some parts
+of the GUI. Following example shows an incomplete implementation of a previewable
+Gaussian filtering.
+
+.. code-block:: python
+
+    from magicclass import magicclass, impl_preview, vfield
+    from magicgui.widgets import Image
+    from scipy import ndimage as ndi
+
+    @magicclass
+    class A:
+        img = vfield(Image)
+
+        def __post_init__(self):
+            # sample image
+            self.img = np.random.random((100, 100))
+            self["img"].min_width = 100
+            self["img"].min_height = 100
+
+        def gaussian_filter(self, sigma: float = 1.0):
+            """Run Gaussian filter inplace"""
+            self.img = ndi.gaussian_filter(self.img, sigma)
+
+        @impl_preview(gaussian_filter)
+        def _prerun(self, sigma):
+            self.gaussian_filter(sigma)
+
+    ui = A()
+    ui.show()
+
+The problem here is that the preview function :meth:`_prerun` updates the GUI state so
+the second preview and the actual run are affected by the previous previews.
+
+Functions wrapped by :meth:`impl_preview` has an additional attribute :meth:`during_preview`,
+which defines a context manager for storing/restoring GUI state.
+
+.. code-block:: python
+
+    @magicclass
+    class A:
+        ...
+
+        @impl_preview(gaussian_filter)
+        def _prerun(self, sigma):
+            self.gaussian_filter(sigma)
+
+        @_prerun.during_preview
+        def _prev_context(self, sigma):
+            original = self.img  # store current image
+            yield  # prerun called here
+            self.img = original  # restore
+
+Auto call
+---------
+
+In the example above, it's nicer to auto-call the preview function. :meth:`impl_preview`
+has an option ``auto_call=True`` to implement this.
+
+.. code-block:: python
+
+    @magicclass
+    class A:
+        ...
+
+        @impl_preview(gaussian_filter, auto_call=True)
+        def _prerun(self, sigma):
+            self.gaussian_filter(sigma)
+
+        @_prerun.during_preview
+        def _prev_context(self, sigma):
+            original = self.img  # store current image
+            yield  # prerun called here
+            self.img = original  # restore
+
+In the auto-call mode, a checkbox (instead of an additional button) will be added to the
+``FunctionGui`` widget. Preview will be auto-called if the checkbox in checked.
+
+Use function itself as the preview
+----------------------------------
+
+As in this example, preview function is usually the same as the target function.
+:meth:`impl_preview` can wrap the target function itself if the first argument is not given.
+
+.. code-block:: python
+
+    from magicclass import magicclass, impl_preview, vfield
+    from magicgui.widgets import Image
+    from scipy import ndimage as ndi
+
+    @magicclass
+    class A:
+        img = vfield(Image)
+
+        def __post_init__(self):
+            # sample image
+            self.img = np.random.random((100, 100))
+            self["img"].min_width = 100
+            self["img"].min_height = 100
+
+        @impl_preview(auto_call=True)  # use gaussian_function as the preview of itself
+        def gaussian_filter(self, sigma: float = 1.0):
+            """Run Gaussian filter inplace"""
+            self.img = ndi.gaussian_filter(self.img, sigma)
+
+        @_prerun.during_preview
+        def _prev_context(self, sigma):
+            original = self.img
+            yield
+            self.img = original
+
+    ui = A()
+    ui.show()
+
+.. note::
+
+    if :meth:`impl_preview` decorator takes no arguments, it should be
+
+    .. code-block:: python
+
+        @impl_preview()
+        def gaussian_filter(self, sigma: float = 1.0):
+            ...
+
+    Do not forget the parentheses.

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -238,7 +238,7 @@ def test_impl_preview_auto_call_and_context():
             self._result += dx
 
         @f.during_preview
-        def _preview(self, x):
+        def _preview(self, dx):
             old = self._result
             yield
             self._result = old

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -103,8 +103,8 @@ def test_nogui():
     assert isinstance(ui["f"], MethodType)
     assert isinstance(ui["g"], PushButton)
 
-def test_mark_preview():
-    from magicclass import mark_preview
+def test_impl_preview():
+    from magicclass import impl_preview
 
     mock = MagicMock()
     @magicclass
@@ -115,8 +115,8 @@ def test_mark_preview():
         def f1(self, x: int = 10):
             mock(x=x)
 
-        @mark_preview(f0, text="preview 0")
-        @mark_preview(f1, text="preview 1")
+        @impl_preview(f0, text="preview 0")
+        @impl_preview(f1, text="preview 1")
         def _preview(self, x):
             mock(x=x, preview=True)
 
@@ -147,6 +147,9 @@ def test_mark_preview():
     mock.assert_called_with(x=10)
     assert str(ui.macro[-1]) == "ui.f1(x=10)"
 
+
+def test_impl_preview_nested():
+    from magicclass import impl_preview
     mock = MagicMock()
 
     @magicclass
@@ -159,8 +162,8 @@ def test_mark_preview():
             def f1(self, x: int = 10):
                 mock(type=type(self), x=x)
 
-        @mark_preview(B.f0, text="preview 0")
-        @mark_preview(B.f1, text="preview 1")
+        @impl_preview(B.f0, text="preview 0")
+        @impl_preview(B.f1, text="preview 1")
         def _preview(self, x):
             mock(type=type(self), x=x, preview=True)
 
@@ -190,6 +193,80 @@ def test_mark_preview():
     f1_gui[-1].changed()
     mock.assert_called_with(type=type(ui.B), x=10)
     assert str(ui.macro[-1]) == "ui.B.f1(x=10)"
+
+
+def test_impl_preview_using_itself():
+    from magicclass import impl_preview
+
+    mock = MagicMock()
+
+    @magicclass
+    class A:
+        @impl_preview()
+        def f(self, i: int):
+            mock(i)
+
+    ui = A()
+    f_gui = get_function_gui(ui, "f")
+    assert f_gui[-2].widget_type == "PushButton"
+
+    mock.assert_not_called()
+
+    f_gui[-2].changed()
+    mock.assert_called_with(0)
+    assert str(ui.macro[-1]).startswith("#")
+    mock.reset_mock()
+
+    f_gui[-1].changed()
+    mock.assert_called_with(0)
+    assert str(ui.macro[-1]) == "ui.f(i=0)"
+
+
+def test_impl_preview_auto_call_and_context():
+    from magicclass import impl_preview
+
+    @magicclass
+    class A:
+        def __init__(self):
+            self._result = 0
+
+        @impl_preview(auto_call=True)
+        def f(self, dx: int):
+            self._result += dx
+
+        @f.during_preview
+        def _preview(self, x):
+            old = self._result
+            yield
+            self._result = old
+
+    ui = A()
+    f_gui = get_function_gui(ui, "f")
+    check_box = f_gui[-2]
+    call_button = f_gui[-1]
+    spinbox = f_gui[0]
+
+    # changing parameters without preview
+    spinbox.value = 1
+    assert ui._result == 0
+
+    # turn on preview
+    check_box.value = True
+    assert ui._result == 1
+
+    spinbox.value = 2
+    assert ui._result == 2
+
+    # turn off
+    check_box.value = False
+    assert ui._result == 0
+
+    spinbox.value = 1
+    assert ui._result == 0
+
+    call_button.changed()
+    assert ui._result == 1
+
 
 def test_confirm():
     from magicclass import confirm

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -238,7 +238,7 @@ def test_impl_preview_auto_call_and_context():
             self._result += dx
 
         @f.during_preview
-        def _preview(self, dx):
+        def _preview(self):
             old = self._result
             yield
             self._result = old

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py38,py39,py310,py311
 requires = tox-conda
 
 [testenv]


### PR DESCRIPTION
This PR makes many types of preview implementation consistent.
This includes migration from `mark_preview` to `impl_preview`.