### PR TITLE
New overload of `get_function_gui`

### DIFF
--- a/magicclass/core.pyi
+++ b/magicclass/core.pyi
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from types import MethodType
 
 from typing import TYPE_CHECKING, Callable, Generic, TypeVar, overload, Any, Protocol
 from typing_extensions import Literal
@@ -30,6 +31,9 @@ class _MagicClassDecorator(Protocol, Generic[_Base]):
     def __call__(self, cls: _C) -> type[_Base] | _C: ...
 
 def build_help(ui: MagicTemplate, parent: QWidget | None = None) -> "HelpWidget": ...
+@overload
+def get_function_gui(method: MethodType) -> FunctionGuiPlus: ...
+@overload
 def get_function_gui(ui: MagicTemplate, name: str) -> FunctionGuiPlus: ...
 @overload
 def magicclass(

--- a/magicclass/utils/qthreading.py
+++ b/magicclass/utils/qthreading.py
@@ -610,7 +610,7 @@ class thread_worker:
         return worker
 
     def _create_method(self, gui: BaseGui):
-        from ..fields import MagicField
+        from magicclass.fields import MagicField
 
         @wraps(self)
         def _create_worker(*args, **kwargs):
@@ -685,6 +685,7 @@ class thread_worker:
 
             return None
 
+        _create_worker.__self__ = gui
         return _create_worker
 
     def _get_method_signature(self) -> inspect.Signature:

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -123,8 +123,8 @@ def test_multi_gui():
     assert a1.choices.choices[0] == id(a1)
     assert a0.choices.choices[1] != a1.choices.choices[1]
 
-    fgui0 = get_function_gui(a0, "f")
-    fgui1 = get_function_gui(a1, "f")
+    fgui0 = get_function_gui(a0.f)
+    fgui1 = get_function_gui(a1.f)
 
     assert fgui0.c.choices[0] == id(a0)
     assert fgui1.c.choices[0] == id(a1)
@@ -142,7 +142,7 @@ def test_choices_with_string():
 
     ui = A()
     assert ui.choices.choices[0] == id(ui)
-    fgui = get_function_gui(ui, "f")
+    fgui = get_function_gui(ui.f)
     assert fgui.c.choices[0] == id(ui)
 
     @magicclass
@@ -159,7 +159,7 @@ def test_choices_with_string():
 
     ui = A()
     assert ui.choices.choices[0] == 1
-    fgui = get_function_gui(ui, "f")
+    fgui = get_function_gui(ui.f)
     assert fgui.c.choices[0] == 1
 
 def test_choices_type():
@@ -183,9 +183,9 @@ def test_choices_type():
             c.bit_length()
 
     ui = A()
-    cbox = get_function_gui(ui, "f").c
+    cbox = get_function_gui(ui.f).c
     assert cbox.choices == (1, 2)
-    cbox = get_function_gui(ui, "g").c
+    cbox = get_function_gui(ui.g).c
     assert cbox.choices == (0, 1)
 
 def test_someof_type():
@@ -209,9 +209,9 @@ def test_someof_type():
             c[0].bit_length()
 
     ui = A()
-    cbox = get_function_gui(ui, "f").c
+    cbox = get_function_gui(ui.f).c
     assert cbox.choices == (1, 2)
-    cbox = get_function_gui(ui, "g").c
+    cbox = get_function_gui(ui.g).c
     assert cbox.choices == (0, 1)
 
 def test_slice_choices():
@@ -224,6 +224,6 @@ def test_slice_choices():
             y.is_integer()
 
     ui = A()
-    fgui = get_function_gui(ui, "f")
+    fgui = get_function_gui(ui.f)
     assert fgui.x.choices == (3, 4, 5)
     assert fgui.y.choices == (0.1, 0.15, 0.2, 0.25)

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -18,12 +18,13 @@ def test_get_choices(widget_type):
             pass
 
     ui = A()
+    fgui = get_function_gui(ui.func)
     ui["func"].changed()
-    assert ui["func"].mgui.x.widget_type == widget_type
-    assert ui["func"].mgui.x.choices == (0, 1, 2)
+    assert fgui.x.widget_type == widget_type
+    assert fgui.x.choices == (0, 1, 2)
     ui._a = [3, 4]
     ui.reset_choices()
-    assert ui["func"].mgui.x.choices == (3, 4)
+    assert fgui.x.choices == (3, 4)
 
 @pytest.mark.parametrize("widget_type", ["ComboBox", "RadioButtons", "Select"])
 def test_nesting(widget_type):
@@ -48,14 +49,16 @@ def test_nesting(widget_type):
     ui = A()
     ui["func"].changed()
     ui.B["func"].changed()
-    assert ui["func"].mgui.x.widget_type == widget_type
-    assert ui["func"].mgui.x.choices == (0, 1, 2)
-    assert ui.B["func"].mgui.x.widget_type == widget_type
-    assert ui.B["func"].mgui.x.choices == (0, 1, 2)
+    fgui0 = get_function_gui(ui.func)
+    fgui1 = get_function_gui(ui.B.func)
+    assert fgui0.x.widget_type == widget_type
+    assert fgui0.x.choices == (0, 1, 2)
+    assert fgui1.x.widget_type == widget_type
+    assert fgui1.x.choices == (0, 1, 2)
     ui.B._a = [3, 4]
     ui.reset_choices()
-    assert ui["func"].mgui.x.choices == (3, 4)
-    assert ui.B["func"].mgui.x.choices == (3, 4)
+    assert fgui0.x.choices == (3, 4)
+    assert fgui1.x.choices == (3, 4)
 
 
 def test_wraps():
@@ -77,11 +80,12 @@ def test_wraps():
 
     ui = A()
     ui["func"].changed()
-    assert ui["func"].mgui.x.widget_type == "ComboBox"
-    assert ui["func"].mgui.x.choices == (0, 1, 2)
+    fgui = get_function_gui(ui.func)
+    assert fgui.x.widget_type == "ComboBox"
+    assert fgui.x.choices == (0, 1, 2)
     ui._a = [3, 4]
     ui.reset_choices()
-    assert ui["func"].mgui.x.choices == (3, 4)
+    assert fgui.x.choices == (3, 4)
 
 def test_field():
     @magicclass

--- a/tests/test_copy_info.py
+++ b/tests/test_copy_info.py
@@ -84,10 +84,10 @@ def test_basic_usage():
     ui = T()
     assert ui.X["f"].text == "Text"
     assert ui.X["f"].tooltip == "doc-f"
-    assert get_function_gui(ui.X, "f").x.min == 1
-    assert get_function_gui(ui.X, "f").layout == "horizontal"
+    assert get_function_gui(ui.X.f).x.min == 1
+    assert get_function_gui(ui.X.f).layout == "horizontal"
     assert ui["g"].tooltip == "doc-g"
-    assert get_function_gui(ui, "g").y.tooltip == "param-y"
+    assert get_function_gui(ui.g).y.tooltip == "param-y"
     assert isinstance(ui["i"], MethodType)
     assert ui.i.__doc__ == "doc-i"
     ui["k"].changed()
@@ -112,7 +112,7 @@ def test_thread_worker():
     assert isinstance(T.f, thread_worker)
     assert ui["f"].tooltip == "doc-f"
     assert ui["f"].text == "Text"
-    assert get_function_gui(ui, "f").x.min == 1
+    assert get_function_gui(ui.f).x.min == 1
 
 def test_wraps():
     @magicclass

--- a/tests/test_functools.py
+++ b/tests/test_functools.py
@@ -94,7 +94,7 @@ def test_singledispatchmethod():
             mock(i, bool)
 
     ui = A()
-    mgui = get_function_gui(ui, "f")
+    mgui = get_function_gui(ui.f)
     wdt = mgui[0]
     assert len(wdt) == 3
 
@@ -138,7 +138,7 @@ def test_singledispatchmethod_with_options():
             mock(i, float)
 
     ui = A()
-    mgui = get_function_gui(ui, "f")
+    mgui = get_function_gui(ui.f)
     wdt = mgui[0]
     assert len(wdt) == 3
 

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -9,8 +9,8 @@ def test_get_function_gui():
         def f(self): ...
 
     ui = A()
-    f = get_function_gui(ui, "f")
-    b = get_function_gui(ui.B, "b")
+    f = get_function_gui(ui.f)
+    b = get_function_gui(ui.B.b)
     assert f is ui["f"].mgui
     assert b is ui.B["b"].mgui
 
@@ -26,7 +26,7 @@ def test_update_widget_state():
             pass
 
     ui = A()
-    fgui = get_function_gui(ui, "f")
+    fgui = get_function_gui(ui.f)
     assert ui.x.value == 0
     assert ui.y == "s"
     assert fgui.asdict() == {"x": 0, "y": 1.0}

--- a/tests/test_return_annotation.py
+++ b/tests/test_return_annotation.py
@@ -21,8 +21,8 @@ def test_return_annotation():
             return s + "-0"
 
     ui = A()
-    fgui_f = get_function_gui(ui, "f")
-    fgui_g = get_function_gui(ui, "g")
+    fgui_f = get_function_gui(ui.f)
+    fgui_g = get_function_gui(ui.g)
 
     assert len(ui.macro) == 1
     mock.assert_not_called()
@@ -45,7 +45,7 @@ def test_return_annotation_auto_call():
             pass
 
     ui = A()
-    fgui_f = get_function_gui(ui, "f")
+    fgui_f = get_function_gui(ui.f)
 
     assert len(ui.macro) == 1
     fgui_f.x.value = 2

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -10,7 +10,7 @@ def test_basics():
             pass
     ui = A()
     ui["f"].changed()
-    opt = get_function_gui(ui, "f")[0]
+    opt = get_function_gui(ui.f)[0]
 
     assert isinstance(opt, widgets.OptionalWidget)
     assert opt.value is None
@@ -24,7 +24,7 @@ def test_set_options():
 
     ui = A()
     ui["f"].changed()
-    opt = get_function_gui(ui, "f")[0]
+    opt = get_function_gui(ui.f)[0]
 
     assert isinstance(opt, widgets.OptionalWidget)
     assert opt.text == "x-text"
@@ -41,7 +41,7 @@ def test_optional_with_annotated():
 
     ui = A()
     ui["f"].changed()
-    opt = get_function_gui(ui, "f")[0]
+    opt = get_function_gui(ui.f)[0]
 
     assert isinstance(opt, widgets.OptionalWidget)
     assert opt.text == "x-text"
@@ -55,7 +55,7 @@ def test_union():
             pass
 
     ui = A()
-    wdt = get_function_gui(ui, "f")[0]
+    wdt = get_function_gui(ui.f)[0]
     assert wdt.widget_type == "UnionWidget"
     assert wdt[0].widget_type == "SpinBox"
     assert wdt[1].widget_type == "LineEdit"
@@ -67,7 +67,7 @@ def test_union_with_default():
             pass
 
     ui = A()
-    wdt = get_function_gui(ui, "f")[0]
+    wdt = get_function_gui(ui.f)[0]
     assert wdt.widget_type == "UnionWidget"
     assert wdt[0].widget_type == "SpinBox"
     assert wdt[1].widget_type == "LineEdit"
@@ -82,7 +82,7 @@ def test_union_with_set_option():
             pass
 
     ui = A()
-    wdt = get_function_gui(ui, "f")[0]
+    wdt = get_function_gui(ui.f)[0]
     assert wdt.widget_type == "UnionWidget"
     assert wdt[0].widget_type == "SpinBox"
     assert wdt[1].widget_type == "FloatSpinBox"
@@ -111,8 +111,8 @@ def test_stored_type():
             pass
 
     ui = A()
-    provide = get_function_gui(ui, "provide")
-    receive = get_function_gui(ui, "receive")
+    provide = get_function_gui(ui.provide)
+    receive = get_function_gui(ui.receive)
     provide(2)
     assert receive.s.choices == (X(2),)
     provide(2)
@@ -149,8 +149,8 @@ def test_stored_last_type():
 
 
     ui = A()
-    provide = get_function_gui(ui, "provide")
-    receive = get_function_gui(ui, "receive")
+    provide = get_function_gui(ui.provide)
+    receive = get_function_gui(ui.receive)
     provide(2)
     assert receive.s.value == X(2)
     provide(3)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -77,8 +77,8 @@ def test_options():
             pass
 
     ui = A()
-    assert get_function_gui(ui, "f").a.widget_type == "LogSlider"
-    assert get_function_gui(ui, "g").a.widget_type == "LogSlider"
+    assert get_function_gui(ui.f).a.widget_type == "LogSlider"
+    assert get_function_gui(ui.g).a.widget_type == "LogSlider"
 
 def test_bind():
     @magicclass(error_mode="stderr")
@@ -97,7 +97,7 @@ def test_bind():
 
     ui = A()
     assert ui.a == 0
-    assert not get_function_gui(ui, "f").a.visible
+    assert not get_function_gui(ui.f).a.visible
     ui["f"].changed()
 
 def test_choice():
@@ -123,8 +123,8 @@ def test_choice():
             mock()
 
     ui = A()
-    assert get_function_gui(ui, "f").a.choices == (0, 1)
-    assert get_function_gui(ui, "g").a.choices == (0, 1)
+    assert get_function_gui(ui.f).a.choices == (0, 1)
+    assert get_function_gui(ui.g).a.choices == (0, 1)
     mock.assert_not_called()
     ui.f(0)
     mock.assert_called_once()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -153,10 +153,10 @@ def test_impl_preview():
             mock(x=x, preview=True)
 
     ui = A()
-    f0_gui = get_function_gui(ui, "f0")
+    f0_gui = get_function_gui(ui.f0)
     assert f0_gui[-2].widget_type == "PushButton"
     assert f0_gui[-2].text == "preview 0"
-    f1_gui = get_function_gui(ui, "f1")
+    f1_gui = get_function_gui(ui.f1)
     assert f1_gui[-2].widget_type == "PushButton"
     assert f1_gui[-2].text == "preview 1"
 
@@ -200,10 +200,10 @@ def test_impl_preview_nested():
             mock(type=type(self), x=x, preview=True)
 
     ui = A()
-    f0_gui = get_function_gui(ui.B, "f0")
+    f0_gui = get_function_gui(ui.B.f0)
     assert f0_gui[-2].widget_type == "PushButton"
     assert f0_gui[-2].text == "preview 0"
-    f1_gui = get_function_gui(ui.B, "f1")
+    f1_gui = get_function_gui(ui.B.f1)
     assert f1_gui[-2].widget_type == "PushButton"
     assert f1_gui[-2].text == "preview 1"
 
@@ -238,7 +238,7 @@ def test_impl_preview_using_itself():
             mock(i)
 
     ui = A()
-    f_gui = get_function_gui(ui, "f")
+    f_gui = get_function_gui(ui.f)
     assert f_gui[-2].widget_type == "PushButton"
 
     mock.assert_not_called()
@@ -272,7 +272,7 @@ def test_impl_preview_auto_call_and_context():
             self._result = old
 
     ui = A()
-    f_gui = get_function_gui(ui, "f")
+    f_gui = get_function_gui(ui.f)
     check_box = f_gui[-2]
     call_button = f_gui[-1]
     spinbox = f_gui[0]
@@ -317,7 +317,7 @@ def test_impl_preview_using_context_only():
             self._result = old
 
     ui = A()
-    f_gui = get_function_gui(ui, "f")
+    f_gui = get_function_gui(ui.f)
     check_box = f_gui[-2]
     call_button = f_gui[-1]
     spinbox = f_gui[0]
@@ -367,7 +367,7 @@ def test_impl_preview_with_cleanup():
                 self._result = None
 
     ui = A()
-    f_gui = get_function_gui(ui, "f")
+    f_gui = get_function_gui(ui.f)
     check_box = f_gui[-2]
     call_button = f_gui[-1]
     spinbox = f_gui[0]
@@ -410,7 +410,7 @@ def test_confirm():
     mconf.assert_not_called()
     ui.f(0)
     mconf.assert_not_called()  # no confirmation if executed programatically
-    get_function_gui(ui, "f")()
+    get_function_gui(ui.f)()
     mconf.assert_value("conf-text")
 
     # text formating
@@ -425,7 +425,7 @@ def test_confirm():
     ui = A()
 
     mconf.assert_not_called()
-    fgui = get_function_gui(ui, "f")
+    fgui = get_function_gui(ui.f)
     fgui()
     mconf.assert_value("<0>")
     fgui.a.value = 16
@@ -445,7 +445,7 @@ def test_confirm():
     ui = A()
 
     mconf.assert_not_called()
-    fgui = get_function_gui(ui, "f")
+    fgui = get_function_gui(ui.f)
     fgui()
     mconf.assert_not_called()
     fgui.a.value = 16
@@ -471,8 +471,8 @@ def test_confirm_with_other_wrapper():
             pass
 
     ui = A()
-    fgui1 = get_function_gui(ui, "f1")
-    fgui2 = get_function_gui(ui, "f2")
+    fgui1 = get_function_gui(ui.f1)
+    fgui2 = get_function_gui(ui.f2)
     assert fgui1.a.max == 10
     assert fgui2.a.max == 12
 
@@ -501,8 +501,8 @@ def test_confirm_with_thread_worker():
             pass
 
     ui = A()
-    fgui1 = get_function_gui(ui, "f1")
-    fgui2 = get_function_gui(ui, "f2")
+    fgui1 = get_function_gui(ui.f1)
+    fgui2 = get_function_gui(ui.f2)
     assert isinstance(A.f1, thread_worker)
     assert isinstance(A.f2, thread_worker)
 


### PR DESCRIPTION
`get_function_gui(ui.method)` is now supported, instead of `get_function_gui(ui, "method")`