### PR TITLE
Implement built-in command palette

### DIFF
--- a/magicclass/_gui/mgui_ext.py
+++ b/magicclass/_gui/mgui_ext.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Callable, Iterable, Any, Generic, TypeVar, Union
+from typing_extensions import TypeGuard
 from qtpy.QtWidgets import (
     QPushButton,
     QAction,
@@ -17,6 +18,10 @@ from ._icon import get_icon
 
 # magicgui widgets that need to be extended to fit into magicclass
 Clickable = Union["PushButtonPlus", "Action"]
+
+
+def is_clickable(wdt: Widget) -> TypeGuard[Clickable]:
+    return isinstance(wdt, (PushButtonPlus, Action))
 
 
 class PushButtonPlus(PushButton):

--- a/magicclass/command_palette.py
+++ b/magicclass/command_palette.py
@@ -1,0 +1,64 @@
+# Built-in command palette for magicclass
+# Currently it is not very customizable.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+from qt_command_palette import get_palette
+from magicclass._gui import BaseGui
+from magicclass._gui.mgui_ext import Clickable, is_clickable
+
+if TYPE_CHECKING:
+    from qt_command_palette._api import CommandPalette
+
+_PALETTES: dict[int, CommandPalette] = {}
+
+
+def exec_command_palette(gui: BaseGui):
+    """
+    Register all the methods available from GUI to the command palette.
+
+    >>> from magicclass import magicclass, bind_key
+    >>> from magicclass.command_palette import exec_command_palette
+    >>> @magicclass
+    >>> class A:
+    ...     def f(self, x: int): ...
+    ...     def g(self): ...
+    ...     @bind_key("F1")
+    ...     def _exec_command_palette(self):
+    ...         exec_command_palette(self)
+
+    Parameters
+    ----------
+    gui : magic-class
+        Magic-class instance.
+    """
+    _id = id(gui)
+    if _id in _PALETTES:
+        return _PALETTES[_id].show_widget(gui.native)
+    name = f"magicclass-{id(gui)}"
+    palette = get_palette(name)
+
+    for parent, wdt in _iter_executable(gui):
+        _qualname = type(parent).__qualname__
+        palette.register(
+            lambda: wdt.clicked.emit(),
+            title=_qualname,
+            desc=wdt.text,
+            when=lambda: wdt.enabled,
+        )
+    _PALETTES[_id] = palette
+    palette.install(gui.native)
+    return palette.show_widget(gui.native)
+
+
+def _iter_executable(gui: BaseGui) -> Iterable[tuple[BaseGui, Clickable]]:
+    for child in gui.__magicclass_children__:
+        yield from _iter_executable(child)
+    for wdt in gui:
+        if is_clickable(wdt):
+            yield gui, wdt
+        elif isinstance(wdt, BaseGui):
+            if wdt in gui.__magicclass_children__:
+                continue
+            yield from _iter_executable(wdt)

--- a/magicclass/widgets/codeedit.py
+++ b/magicclass/widgets/codeedit.py
@@ -167,10 +167,10 @@ class QCodeEditor(QtW.QPlainTextEdit):
             return None
 
     def _open_magicgui(self, pos: QtCore.QPoint):
-        from magicclass._gui.mgui_ext import PushButtonPlus, Action
+        from magicclass._gui.mgui_ext import is_clickable
 
         info = self.wordAt(pos)
-        if info and isinstance(info.obj, (PushButtonPlus, Action)):
+        if info and is_clickable(info.obj):
             mgui = info.obj.mgui
             if mgui is None:
                 return show_messagebox("error", "Error", "No magicgui found", self)


### PR DESCRIPTION
Automatically create command palette with `exec_command_palette`.

```python
from magicclass import magicclass, bind_key
from magicclass.command_palette import exec_command_palette

@magicclass
class A:
    def f(self, x: int):
        print(x)

    def g(self):
        print(0)

    @bind_key("F1")
    def _exec_command_palette(self):
        exec_command_palette(self)

ui = A()
ui.show()
```