### PR TITLE
Fix macro-recording bugs with nested workers

### DIFF
--- a/magicclass/utils/qthreading.py
+++ b/magicclass/utils/qthreading.py
@@ -32,7 +32,7 @@ from magicclass.widgets.containers import FrameContainer
 
 if TYPE_CHECKING:
     from magicclass._gui import BaseGui
-    from magicclass._gui.mgui_ext import PushButtonPlus, Action
+    from magicclass._gui.mgui_ext import Clickable
     from magicclass._gui._macro import GuiMacro
     from magicclass.fields import MagicField
     from typing_extensions import Self
@@ -683,7 +683,7 @@ class thread_worker(Generic[_P]):
                 if hasattr(pbar, "set_title"):
                     pbar.set_title(self._func.__name__.replace("_", " "))
 
-            _obj: PushButtonPlus | Action = gui[self._func.__name__]
+            _obj: Clickable = gui[self._func.__name__]
             if _obj.running:
                 worker.errored.connect(
                     partial(gui._error_mode.get_handler(), parent=gui)

--- a/magicclass/widgets/codeedit.py
+++ b/magicclass/widgets/codeedit.py
@@ -384,7 +384,7 @@ class QCodeEditor(QtW.QPlainTextEdit):
                 int(self._line_number_area.width() - 2),
                 int(height),
                 Qt.AlignmentFlag.AlignRight,
-                str(num + 1),
+                str(num),
             )
 
     def _highlight_current_line(self):


### PR DESCRIPTION
```python
@thread_worker
def f(self):
    self.g()  # <---- this used to be recorded!
```