### PR TITLE
Fix GenericAlias bugs in python 3.11

### DIFF
--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -9,7 +9,6 @@ from typing import (
     Generic,
 )
 from typing_extensions import Literal, _AnnotatedAlias
-import sys
 from magicgui.widgets import create_widget, Widget
 from magicclass._magicgui_compat import (
     ValueWidget,
@@ -25,6 +24,7 @@ from magicclass.utils import (
     is_instance_method,
     method_as_getter,
     eval_attribute,
+    is_type_like,
 )
 from magicclass.signature import MagicMethodSignature
 from magicclass._gui.mgui_ext import Action, WidgetAction
@@ -36,11 +36,6 @@ if TYPE_CHECKING:
 
     _M = TypeVar("_M", bound=MagicTemplate)
     _X = TypeVar("_X", bound=MGUI_SIMPLE_TYPES)
-
-if sys.version_info >= (3, 10):
-    from typing import _BaseGenericAlias
-else:
-    from typing_extensions import _BaseGenericAlias
 
 
 class _FieldObject:
@@ -946,7 +941,7 @@ def _get_field(
     kwargs = dict(
         name=name, label=label, record=record, annotation=None, options=options
     )
-    if isinstance(obj, (type, _BaseGenericAlias)):
+    if is_type_like(obj):
         if isinstance(obj, _AnnotatedAlias):
             from magicclass.signature import split_annotated_type
 

--- a/magicclass/types.py
+++ b/magicclass/types.py
@@ -24,6 +24,7 @@ from magicgui.widgets import Widget, EmptyWidget
 
 from magicclass.fields import MagicField
 from magicclass.signature import split_annotated_type
+from magicclass.utils import is_type_like
 
 try:
     from typing import _tp_cache
@@ -488,7 +489,7 @@ class _OptionalAlias(type):
         ...
 
     def __getitem__(cls, value):
-        if not _is_type_like(value):
+        if not is_type_like(value):
             raise TypeError(
                 "The first argument of Optional must be a type but "
                 f"got {type(value)}."
@@ -780,7 +781,7 @@ class Stored(Generic[_T], metaclass=_StoredMeta):
                 raise TypeError("Input of Stored must be a type or (type, Any)")
             _tp, _hash = value
         else:
-            if not _is_type_like(value):
+            if not is_type_like(value):
                 raise TypeError(
                     "The first argument of Stored must be a type but "
                     f"got {type(value)}."
@@ -799,10 +800,6 @@ class Stored(Generic[_T], metaclass=_StoredMeta):
         outtype.__args__ = (_tp,)
         _StoredMeta._instances[key] = outtype
         return outtype
-
-
-def _is_type_like(x: Any):
-    return isinstance(x, (type, typing._GenericAlias)) or hasattr(x, "__supertype__")
 
 
 def _repr_like(x: Any):

--- a/magicclass/utils/__init__.py
+++ b/magicclass/utils/__init__.py
@@ -9,6 +9,7 @@ from ._functions import (
     copy_info,
     show_tree,
     rst_to_html,
+    is_type_like,
 )
 
 from .qt import (

--- a/magicclass/utils/_functions.py
+++ b/magicclass/utils/_functions.py
@@ -9,6 +9,20 @@ from docstring_parser import parse
 if TYPE_CHECKING:
     from magicclass._gui import BaseGui
 
+try:
+    from typing import _BaseGenericAlias
+except ImportError:
+    from typing_extensions import _BaseGenericAlias
+
+_type_like = (type, _BaseGenericAlias)
+
+try:
+    from types import GenericAlias
+
+    _type_like += (GenericAlias,)
+except ImportError:
+    pass
+
 
 def iter_members(cls: type, exclude_prefix: str = "__") -> Iterable[tuple[str, Any]]:
     """
@@ -222,3 +236,7 @@ def _copy_info(src: type, dst: type) -> None:
                 dst_attr.__doc__ = attr.__doc__
 
     return None
+
+
+def is_type_like(x: Any) -> bool:
+    return isinstance(x, _type_like) or hasattr(x, "__supertype__")


### PR DESCRIPTION
We have to use `types.GenericAlias` in some cases.