### PR TITLE
Reactivate macro when exception happend in a GeneratorWorker

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,14 +6,12 @@ from magicclass import (
     vfield,
     FieldGroup,
     HasFields,
-    set_design,
 )
 from magicclass.fields import widget_property
 from magicclass.types import Optional
 from magicgui import widgets
 from typing import Tuple
 from unittest.mock import MagicMock
-from pathlib import Path
 
 def test_field_types():
     @magicclass

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+import pytest
 from magicclass import magicclass, magicmenu, set_options, do_not_record, vfield, get_function_gui
 from magicclass.types import Bound
 from magicclass.utils import thread_worker


### PR DESCRIPTION
Context manager cannot catch the errors raised in the GeneratorWorker.
Reactivate macro manually in the `errored` signal.