### PR TITLE
Implement `Box` types

### DIFF
--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -75,6 +75,7 @@ from magicclass.signature import (
 from magicclass.wrappers import abstractapi
 from magicclass.types import BoundLiteral, MGUI_SIMPLE_TYPES
 from magicclass.functools import wraps
+from magicclass.box._fields import BoxMagicField
 
 if TYPE_CHECKING:
     import numpy as np
@@ -891,7 +892,7 @@ class ContainerLikeGui(BaseGui[Union[Action, Widget]], mguiLike):
 
         if action.support_value and fld.record:
             # By default, set value function will be connected to the widget.
-            getvalue = type(fld) is MagicField
+            getvalue = type(fld) in (MagicField, BoxMagicField)
             f = value_widget_callback(self, action, name, getvalue=getvalue)
             action.changed.connect(f)
 

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -49,9 +49,11 @@ from magicclass.widgets import (
     SplitterContainer,
     StackedContainer,
     TabbedContainer,
+    ResizableContainer,
     ToolBoxContainer,
     FreeWidget,
 )
+from magicclass.widgets._box import Box
 
 from magicclass.utils import iter_members, Tooltips
 from magicclass.fields import MagicField
@@ -328,11 +330,13 @@ class ClassGuiBase(BaseGui[Widget]):
                     widget._my_symbol = Symbol(widget.name)
 
         _widget = widget
+        if isinstance(widget, Box):
+            widget = widget.widget
 
         if self.labels:
             # no labels for button widgets (push buttons, checkboxes, have their own)
             if not isinstance(widget, _HIDE_LABELS) and not remove_label:
-                _widget = _LabeledWidget(widget)
+                _widget = _LabeledWidget(_widget)
                 widget.label_changed.connect(self._unify_label_widths)
 
         if key < 0:
@@ -664,6 +668,8 @@ class SubWindowsClassGui: pass
 class GroupBoxClassGui: pass
 @make_gui(FrameContainer, no_margin=False)
 class FrameClassGui: pass
+@make_gui(ResizableContainer, no_margin=False)
+class ResizableClassGui: pass
 @make_gui(MainWindow)
 class MainWindowClassGui: pass
 # fmt: on

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -54,6 +54,7 @@ from magicclass.widgets import (
     FreeWidget,
 )
 from magicclass.widgets._box import Box
+from magicclass.box._fields import BoxMagicField
 
 from magicclass.utils import iter_members, Tooltips
 from magicclass.fields import MagicField
@@ -96,7 +97,7 @@ class ClassGuiBase(BaseGui[Widget]):
         if isinstance(widget, (ValueWidget, ContainerWidget)):
             # If the field has callbacks, connect it to the newly generated widget.
             if fld.record:
-                getvalue = type(fld) is MagicField
+                getvalue = type(fld) in (MagicField, BoxMagicField)
                 if isinstance(widget, ValueWidget):
                     if widget._bound_value is Undefined:
                         f = value_widget_callback(self, widget, name, getvalue=getvalue)

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -94,6 +94,13 @@ class ClassGuiBase(BaseGui[Widget]):
             self.__magicclass_children__.append(widget)
             widget._my_symbol = Symbol(name)
 
+        elif isinstance(fld, BoxMagicField):
+            for wdt in widget:
+                if isinstance(wdt, BaseGui):
+                    wdt.__magicclass_parent__ = self
+                    self.__magicclass_children__.append(wdt)
+                    wdt._my_symbol = Symbol(name)
+
         if isinstance(widget, (ValueWidget, ContainerWidget)):
             # If the field has callbacks, connect it to the newly generated widget.
             if fld.record:

--- a/magicclass/box/__init__.py
+++ b/magicclass/box/__init__.py
@@ -1,4 +1,4 @@
-from ._box import resizable, draggable, scrollable, collapsible
+from ._fields import resizable, draggable, scrollable, collapsible
 
 __all__ = [
     "resizable",

--- a/magicclass/box/__init__.py
+++ b/magicclass/box/__init__.py
@@ -1,0 +1,8 @@
+from ._box import resizable, draggable, scrollable, collapsible
+
+__all__ = [
+    "resizable",
+    "draggable",
+    "scrollable",
+    "collapsible",
+]

--- a/magicclass/box/_box.py
+++ b/magicclass/box/_box.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+from typing import Any, Callable, TYPE_CHECKING, Literal, Protocol, TypeVar, overload
+
+from magicgui.widgets.bases import Widget, ValueWidget
+from magicclass.fields import MagicField, MagicValueField
+
+if TYPE_CHECKING:
+    from magicclass._gui import MagicTemplate
+    from magicclass.widgets._box import Box
+
+_W = TypeVar("_W", bound=Widget)
+_V = TypeVar("_V")
+
+
+def make_constructor(
+    fld: MagicField[_W],
+    box_cls: type[Box],
+) -> Callable[[Any], Box[_W]]:
+    def construct_widget(obj: Any) -> Widget:
+        widget = fld.construct(obj)
+        return box_cls.from_widget(widget)
+
+    return construct_widget
+
+
+class BoxMagicField(MagicField[_W]):
+    @classmethod
+    def from_field(cls, fld: MagicField[_W], box_cls: type[Box]) -> BoxMagicField[_W]:
+        constructor = make_constructor(fld, box_cls)
+        return cls(
+            value=fld.value,
+            name=fld.name,
+            label=fld.label,
+            annotation=fld.annotation,
+            widget_type=box_cls,
+            options=fld.options,
+            constructor=constructor,
+        )
+
+    @classmethod
+    def from_widget_type(
+        cls,
+        widget_type: type[_W],
+        box_cls: type[Box],
+    ) -> BoxMagicField[_W]:
+        fld = MagicField(widget_type=widget_type)
+        return cls.from_field(fld, box_cls)
+
+    @classmethod
+    def from_any(cls, obj: Any, box_cls: type[Box]) -> BoxMagicField[_W]:
+        if isinstance(obj, MagicField):
+            return cls.from_field(obj, box_cls)
+        elif isinstance(obj, type):
+            return cls.from_widget_type(obj, box_cls)
+        else:
+            raise TypeError(f"Cannot make BoxMagicField from {obj!r}")
+
+    def get_widget(self, obj: Any) -> Box[_W]:
+        return super().get_widget(obj)
+
+    def as_getter(self, obj: Any) -> Callable[[Any], Any]:
+        """Make a function that get the value of Widget or Action."""
+        return lambda w: self._guis[id(obj)].widget.value
+
+    @overload
+    def __get__(self, obj: Literal[None], objtype=None) -> BoxMagicField[_W]:
+        ...
+
+    @overload
+    def __get__(self, obj: Any, objtype=None) -> _W:
+        ...
+
+    def __get__(self, obj, objtype=None):
+        """Get widget for the object."""
+        if obj is None:
+            return self
+        return self.get_widget(obj).widget
+
+
+class BoxMagicValueField(BoxMagicField[ValueWidget[_V]]):
+    @overload
+    def __get__(self, obj: Literal[None], objtype=None) -> BoxMagicValueField[_V]:
+        ...
+
+    @overload
+    def __get__(self, obj: Any, objtype=None) -> _V:
+        ...
+
+    def __get__(self, obj, objtype=None):
+        """Get widget for the object."""
+        if obj is None:
+            return self
+        return self.get_widget(obj).widget.value
+
+    def __set__(self, obj: MagicTemplate, value: _V) -> None:
+        if obj is None:
+            raise AttributeError(f"Cannot set {self.__class__.__name__}.")
+        self.get_widget(obj).widget.value = value
+
+
+class BoxProtocol(Protocol):
+    @overload
+    def __call__(self, fld: MagicField[_W]) -> BoxMagicField[_W]:
+        ...
+
+    @overload
+    def __call__(self, widget_type: type[_W]) -> BoxMagicField[_W]:
+        ...
+
+    @overload
+    def __call__(self, fld: MagicValueField[_V]) -> BoxMagicValueField[_V]:
+        ...
+
+
+if TYPE_CHECKING:
+
+    def _boxifier(f) -> BoxProtocol:
+        ...  # fmt: skip
+
+else:
+    _boxifier = lambda x: x
+
+
+@_boxifier
+def resizable(obj):
+    """Convert a widget or a field to a resizable one."""
+    from magicclass.widgets._box import ResizableBox
+
+    return BoxMagicField.from_any(obj, ResizableBox)
+
+
+@_boxifier
+def draggable(obj):
+    """Convert a widget or a field to a draggable one."""
+    from magicclass.widgets._box import DraggableBox
+
+    return BoxMagicField.from_any(obj, DraggableBox)
+
+
+@_boxifier
+def scrollable(obj):
+    """Convert a widget or a field to a scrollable one."""
+    from magicclass.widgets._box import ScrollableBox
+
+    return BoxMagicField.from_any(obj, ScrollableBox)
+
+
+@_boxifier
+def collapsible(obj):
+    """Convert a widget or a field to a collapsible one."""
+    from magicclass.widgets._box import CollapsibleBox
+
+    return BoxMagicField.from_any(obj, CollapsibleBox)

--- a/magicclass/box/_fields.py
+++ b/magicclass/box/_fields.py
@@ -157,6 +157,8 @@ def resizable(obj):
     """Convert a widget or a field to a resizable one."""
     from magicclass.widgets._box import ResizableBox
 
+    if isinstance(obj, MagicValueField):
+        return BoxMagicValueField.from_field(obj, ResizableBox)
     return BoxMagicField.from_any(obj, ResizableBox)
 
 
@@ -165,6 +167,8 @@ def draggable(obj):
     """Convert a widget or a field to a draggable one."""
     from magicclass.widgets._box import DraggableBox
 
+    if isinstance(obj, MagicValueField):
+        return BoxMagicValueField.from_field(obj, DraggableBox)
     return BoxMagicField.from_any(obj, DraggableBox)
 
 
@@ -173,6 +177,8 @@ def scrollable(obj):
     """Convert a widget or a field to a scrollable one."""
     from magicclass.widgets._box import ScrollableBox
 
+    if isinstance(obj, MagicValueField):
+        return BoxMagicValueField.from_field(obj, ScrollableBox)
     return BoxMagicField.from_any(obj, ScrollableBox)
 
 
@@ -181,6 +187,13 @@ def collapsible(obj, orientation: Literal["horizontal", "vertical"] = "vertical"
     """Convert a widget or a field to a collapsible one."""
     from magicclass.widgets._box import CollapsibleBox, HCollapsibleBox
 
-    if orientation == "horizontal":
-        return BoxMagicField.from_any(obj, HCollapsibleBox)
-    return BoxMagicField.from_any(obj, CollapsibleBox)
+    if orientation == "vertical":
+        box_cls = CollapsibleBox
+    elif orientation == "horizontal":
+        box_cls = HCollapsibleBox
+    else:
+        raise ValueError(f"Invalid orientation: {orientation!r}")
+
+    if isinstance(obj, MagicValueField):
+        return BoxMagicValueField.from_field(obj, box_cls)
+    return BoxMagicField.from_any(obj, box_cls)

--- a/magicclass/core.py
+++ b/magicclass/core.py
@@ -23,6 +23,7 @@ from magicclass._gui.class_gui import (
     TabbedClassGui,
     StackedClassGui,
     ToolBoxClassGui,
+    ResizableClassGui,
     ListClassGui,
 )
 from magicclass._gui._base import (
@@ -67,6 +68,7 @@ _TYPE_MAP: dict[WidgetType, type[ClassGuiBase]] = {
     WidgetType.list: ListClassGui,
     WidgetType.groupbox: GroupBoxClassGui,
     WidgetType.frame: FrameClassGui,
+    WidgetType.resizable: ResizableClassGui,
     WidgetType.subwindows: SubWindowsClassGui,
     WidgetType.mainwindow: MainWindowClassGui,
 }

--- a/magicclass/fields/__init__.py
+++ b/magicclass/fields/__init__.py
@@ -8,3 +8,16 @@ from ._fields import (
 )
 from ._group import HasFields, FieldGroup, dataclass_gui
 from ._property import magicproperty
+
+__all__ = [
+    "field",
+    "vfield",
+    "widget_property",
+    "MagicField",
+    "MagicValueField",
+    "method_as_getter",
+    "HasFields",
+    "FieldGroup",
+    "dataclass_gui",
+    "magicproperty",
+]

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -71,7 +71,7 @@ class MagicField(_FieldObject, Generic[_W]):
         widget_type: type | str | None = None,
         options: dict[str, Any] | None = None,
         record: bool = True,
-        constructor: Callable[..., Widget] | None = None,
+        constructor: Callable[[Any], Widget] | None = None,
     ):
         if options is None:
             options = {}
@@ -93,8 +93,8 @@ class MagicField(_FieldObject, Generic[_W]):
             constructor = _create_widget
 
         self.value = value
-        self.name = name
-        self.label = label
+        self.name = name or ""
+        self.label = label or ""
         self.annotation = annotation
         self.options = options
         self._widget_type = widget_type
@@ -196,6 +196,12 @@ class MagicField(_FieldObject, Generic[_W]):
         self.options["choices"] = choices
         return self
 
+    def with_widget_type(self, widget_type: type[Widget]):
+        """Method to add widget type to the field."""
+        new = self.copy()
+        new._widget_type = widget_type
+        return new
+
     @property
     def __signature__(self):
         """This property is necessary to hack _unwrap_method."""
@@ -205,7 +211,7 @@ class MagicField(_FieldObject, Generic[_W]):
         return MagicMethodSignature([], additional_options=additional_options)
 
     @property
-    def constructor(self) -> Callable[..., Widget]:
+    def constructor(self) -> Callable[[Any], Widget]:
         """Get widget constructor."""
         return self._constructor
 

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -83,8 +83,8 @@ class MagicField(_FieldObject, Generic[_W]):
             def _create_widget(obj):
                 return create_widget(
                     self.value,
-                    name=self.name,
-                    label=self.label,
+                    name=self.name or "",
+                    label=self.label or "",
                     annotation=self.annotation,
                     widget_type=self.widget_type,
                     options=self.options,
@@ -93,8 +93,8 @@ class MagicField(_FieldObject, Generic[_W]):
             constructor = _create_widget
 
         self.value = value
-        self.name = name or ""
-        self.label = label or ""
+        self.name = name
+        self.label = label
         self.annotation = annotation
         self.options = options
         self._widget_type = widget_type
@@ -270,15 +270,17 @@ class MagicField(_FieldObject, Generic[_W]):
 
     def get_widget(self, obj: Any) -> _W:
         """
-        Get a widget from ``obj``. This function will be called every time MagicField is referred
-        by ``obj.field``.
+        Get a widget from ``obj``.
+
+        This function will be called every time MagicField is referred by
+        ``obj.field``.
         """
         from magicclass._gui import MagicTemplate
 
         obj_id = id(obj)
         if (widget := self._guis.get(obj_id, None)) is None:
             self._guis[obj_id] = widget = self.construct(obj)
-            widget.name = self.name
+            widget.name = self.name or ""
 
             if isinstance(widget, (ValueWidget, ContainerWidget)):
                 if isinstance(obj, MagicTemplate):

--- a/magicclass/types/_const.py
+++ b/magicclass/types/_const.py
@@ -21,6 +21,7 @@ class WidgetType(Enum):
     subwindows = "subwindows"
     groupbox = "groupbox"
     frame = "frame"
+    resizable = "resizable"
     mainwindow = "mainwindow"
 
 
@@ -38,6 +39,7 @@ WidgetTypeStr = Literal[
     "subwindows",
     "groupbox",
     "frame",
+    "resizable",
     "mainwindow",
     "hcollapsible",
 ]
@@ -55,7 +57,7 @@ PopUpModeStr = Literal[
 ]
 
 
-ErrorModeStr = Literal["msgbox", "stderr", "stdout", "napari", "debug"]
+ErrorModeStr = Literal["msgbox", "stderr", "stdout", "napari", "debug", "ignore"]
 
 Color = Union[Iterable[float], str]
 Colormap = Dict[float, Color]

--- a/magicclass/widgets/__init__.py
+++ b/magicclass/widgets/__init__.py
@@ -16,6 +16,7 @@ from .containers import (
     StackedContainer,
     TabbedContainer,
     ToolBoxContainer,
+    ResizableContainer,
 )
 from .pywidgets import ListWidget, DictWidget
 from .color import ColorEdit, ColorSlider
@@ -62,6 +63,7 @@ __all__ = [
     "Logger",
     "OneLineRunner",
     "OptionalWidget",
+    "ResizableContainer",
     "SeabornFigure",
     "Separator",
     "ScrollableContainer",

--- a/magicclass/widgets/_box.py
+++ b/magicclass/widgets/_box.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TypeVar
+from magicgui.widgets import Widget
+from magicgui.widgets.bases import ContainerWidget
+from magicclass.widgets.containers import (
+    DraggableContainer,
+    ResizableContainer,
+    ScrollableContainer,
+    CollapsibleContainer,
+    HCollapsibleContainer,
+)
+
+_W = TypeVar("_W", bound=Widget)
+
+
+class Box(ContainerWidget[_W]):
+    @classmethod
+    def from_widget(cls, widget: _W):
+        out = cls(
+            widgets=[widget],
+            label=widget.label or widget.name or "",
+            name=widget.name,
+        )
+        return out
+
+    @property
+    def widget(self) -> _W:
+        return self[0]
+
+    @property
+    def labels(self) -> bool:
+        return False
+
+
+class ResizableBox(Box, ResizableContainer):
+    pass
+
+
+class ScrollableBox(Box, ScrollableContainer):
+    pass
+
+
+class DraggableBox(Box, DraggableContainer):
+    pass
+
+
+class CollapsibleBox(Box, CollapsibleContainer):
+    pass

--- a/magicclass/widgets/_box.py
+++ b/magicclass/widgets/_box.py
@@ -21,7 +21,7 @@ class Box(ContainerWidget[_W]):
         return False
 
 
-class SingleWidgetBox(Box):
+class SingleWidgetBox(Box[_W]):
     @classmethod
     def from_widget(cls, widget: _W):
         out = cls(
@@ -41,21 +41,21 @@ class SingleWidgetBox(Box):
         return self.widget.value
 
 
-class ResizableBox(SingleWidgetBox, ResizableContainer):
+class ResizableBox(SingleWidgetBox[_W], ResizableContainer):
     pass
 
 
-class ScrollableBox(SingleWidgetBox, ScrollableContainer):
+class ScrollableBox(SingleWidgetBox[_W], ScrollableContainer):
     pass
 
 
-class DraggableBox(SingleWidgetBox, DraggableContainer):
+class DraggableBox(SingleWidgetBox[_W], DraggableContainer):
     pass
 
 
-class CollapsibleBox(SingleWidgetBox, CollapsibleContainer):
+class CollapsibleBox(SingleWidgetBox[_W], CollapsibleContainer):
     pass
 
 
-class HCollapsibleBox(SingleWidgetBox, HCollapsibleContainer):
+class HCollapsibleBox(SingleWidgetBox[_W], HCollapsibleContainer):
     pass

--- a/magicclass/widgets/_box.py
+++ b/magicclass/widgets/_box.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TypeVar
-import weakref
 from magicgui.widgets import Widget
 from magicgui.widgets.bases import ContainerWidget
 from magicclass.widgets.containers import (
@@ -16,22 +15,6 @@ _W = TypeVar("_W", bound=Widget)
 
 
 class Box(ContainerWidget[_W]):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self._magicclass_parent_ref = None
-
-    @property
-    def __magicclass_parent__(self):
-        if self._magicclass_parent_ref is None:
-            return None
-        return self._magicclass_parent_ref()
-
-    @__magicclass_parent__.setter
-    def __magicclass_parent__(self, value):
-        if value is None:
-            self._magicclass_parent_ref = None
-        self._magicclass_parent_ref = weakref.ref(value)
-
     @property
     def labels(self) -> bool:
         """Always not labeled."""
@@ -46,8 +29,7 @@ class SingleWidgetBox(Box):
             label=widget.label or widget.name or "",
             name=widget.name,
         )
-        if hasattr(type(widget), "__magicclass_parent__"):
-            widget.__magicclass_parent__ = out
+        out.margins = (0, 0, 0, 0)
         return out
 
     @property

--- a/magicclass/widgets/_box.py
+++ b/magicclass/widgets/_box.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TypeVar
+import weakref
 from magicgui.widgets import Widget
 from magicgui.widgets.bases import ContainerWidget
 from magicclass.widgets.containers import (
@@ -15,6 +16,29 @@ _W = TypeVar("_W", bound=Widget)
 
 
 class Box(ContainerWidget[_W]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._magicclass_parent_ref = None
+
+    @property
+    def __magicclass_parent__(self):
+        if self._magicclass_parent_ref is None:
+            return None
+        return self._magicclass_parent_ref()
+
+    @__magicclass_parent__.setter
+    def __magicclass_parent__(self, value):
+        if value is None:
+            self._magicclass_parent_ref = None
+        self._magicclass_parent_ref = weakref.ref(value)
+
+    @property
+    def labels(self) -> bool:
+        """Always not labeled."""
+        return False
+
+
+class SingleWidgetBox(Box):
     @classmethod
     def from_widget(cls, widget: _W):
         out = cls(
@@ -22,6 +46,8 @@ class Box(ContainerWidget[_W]):
             label=widget.label or widget.name or "",
             name=widget.name,
         )
+        if hasattr(type(widget), "__magicclass_parent__"):
+            widget.__magicclass_parent__ = out
         return out
 
     @property
@@ -29,21 +55,25 @@ class Box(ContainerWidget[_W]):
         return self[0]
 
     @property
-    def labels(self) -> bool:
-        return False
+    def value(self):
+        return self.widget.value
 
 
-class ResizableBox(Box, ResizableContainer):
+class ResizableBox(SingleWidgetBox, ResizableContainer):
     pass
 
 
-class ScrollableBox(Box, ScrollableContainer):
+class ScrollableBox(SingleWidgetBox, ScrollableContainer):
     pass
 
 
-class DraggableBox(Box, DraggableContainer):
+class DraggableBox(SingleWidgetBox, DraggableContainer):
     pass
 
 
-class CollapsibleBox(Box, CollapsibleContainer):
+class CollapsibleBox(SingleWidgetBox, CollapsibleContainer):
+    pass
+
+
+class HCollapsibleBox(SingleWidgetBox, HCollapsibleContainer):
     pass

--- a/magicclass/widgets/containers.py
+++ b/magicclass/widgets/containers.py
@@ -490,6 +490,28 @@ class _FrameContainer(_GroupBoxContainer):
         self._groupbox.setTitle("")
 
 
+class _ResizableContainer(ContainerBase):
+    def __init__(self, layout="vertical", scrollable: bool = False, **kwargs):
+        QBaseWidget.__init__(self, QtW.QWidget)
+        if layout == "horizontal":
+            self._layout: QtW.QLayout = QtW.QHBoxLayout()
+            self._layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        else:
+            self._layout = QtW.QVBoxLayout()
+            self._layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+        self._inner_qwidget = QtW.QWidget(self._qwidget)
+        self._inner_qwidget.setLayout(self._layout)
+
+        self._qwidget.setLayout(QtW.QVBoxLayout())
+        _size_grip = QtW.QSizeGrip(self._qwidget)
+        self._qwidget.layout().addWidget(self._inner_qwidget)
+        self._qwidget.layout().addWidget(
+            _size_grip, 1, Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignRight
+        )
+        self._qwidget.layout().setContentsMargins(0, 0, 0, 0)
+
+
 # Container Widgets
 
 
@@ -683,3 +705,8 @@ class GroupBoxContainer(ContainerWidget):
 @wrap_container(base=_FrameContainer)
 class FrameContainer(ContainerWidget):
     """A QGroupBox like container without title."""
+
+
+@wrap_container(base=_ResizableContainer)
+class ResizableContainer(ContainerWidget):
+    """A resizable Container Widget."""

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -685,3 +685,66 @@ def test_with_choices():
     assert ui["b_int1"].widget_type == "ComboBox"
     assert ui["a_int2"].widget_type == "ComboBox"
     assert ui["b_int2"].widget_type == "ComboBox"
+
+def test_box():
+    from magicclass import box
+
+    @magicclass
+    class A:
+        x0 = box.resizable(field(int))
+        x1 = box.resizable(vfield(int))
+        y0 = box.scrollable(field(int))
+        y1 = box.scrollable(vfield(int))
+        z0 = box.draggable(field(int))
+        z1 = box.draggable(vfield(int))
+        w0 = box.collapsible(field(int))
+        w1 = box.collapsible(vfield(int))
+
+    ui = A()
+    ui.x0.value = 1
+    ui.x1 = 2
+    ui.y0.value = 3
+    ui.y1 = 4
+    ui.z0.value = 5
+    ui.z1 = 6
+    ui.w0.value = 7
+    ui.w1 = 8
+
+    assert ui.x0.value == 1
+    assert ui.x1 == 2
+    assert ui.y0.value == 3
+    assert ui.y1 == 4
+    assert ui.z0.value == 5
+    assert ui.z1 == 6
+    assert ui.w0.value == 7
+    assert ui.w1 == 8
+
+    assert str(ui.macro[1]) == "ui.x0.value = 1"
+    assert str(ui.macro[2]) == "ui.x1 = 2"
+    assert str(ui.macro[3]) == "ui.y0.value = 3"
+    assert str(ui.macro[4]) == "ui.y1 = 4"
+    assert str(ui.macro[5]) == "ui.z0.value = 5"
+    assert str(ui.macro[6]) == "ui.z1 = 6"
+    assert str(ui.macro[7]) == "ui.w0.value = 7"
+    assert str(ui.macro[8]) == "ui.w1 = 8"
+
+def test_magicclass_in_box():
+    from magicclass.box import resizable
+
+    @magicclass
+    class A:
+        def f(self):
+            pass
+        x = field(int)
+
+    @magicclass
+    class B:
+        xx = field(A)
+        a = resizable(field(A))
+
+    ui = B()
+    ui.a.f()
+    ui.a.x.value = 123
+
+    assert str(ui.macro[1]) == "ui.a.f()"
+    assert str(ui.macro[2]) == "ui.a.x.value = 123"

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -4,6 +4,7 @@ from magicclass import (
     magictoolbar,
     field,
     vfield,
+    abstractapi,
     FieldGroup,
     HasFields,
 )
@@ -748,3 +749,29 @@ def test_magicclass_in_box():
 
     assert str(ui.macro[1]) == "ui.a.f()"
     assert str(ui.macro[2]) == "ui.a.x.value = 123"
+
+def test_box_with_wraps():
+    from magicclass.box import resizable
+
+    @magicclass
+    class A:
+        x = abstractapi()
+
+    @magicclass
+    class B0:
+        a0 = resizable(field(A))
+
+        @a0.wraps
+        def x(self):
+            pass
+
+    @magicclass
+    class B1:
+        a0 = resizable(A)
+
+        @a0.wraps
+        def x(self):
+            pass
+
+    B0().x()
+    B1().x()


### PR DESCRIPTION
Currently, to make widgets of scrollable, collapsible etc., one must rely on `@magicclass` decorator with the `widget_type` argument. This is, however, not efficient if the magic class has only one field.

```python
from magicclass import magicclass, field
from magicclass.widgets import Figure

@magicclass
class A:
    @magicclass(widget_type="scrollable")
    class Plot:
        plt = field(Figure)

ui = A()
ui.Plot.plt.plot(...)  # <-- "Plot" is required here :(
```

This PR implements a type called `Box`, which adds some functions to a field or a widget class. The word "box" comes from the `Box` type in Rust, which behaves in a similar way but for different purposes.

```python
from magicclass import magicclass, field
from magicclass.widgets import Figure
from magicclass.box import resizable

@magicclass
class A:
    plt = resizable(field(Figure))  # as if `plt = field(Figure)`

ui = A()
ui.plt.plot(...)  # <-- OK, and type safe!
```

TODOs
--------

- [x] macro recording of the inner field.
- [x] callback functions of the inner field.
- [ ] abstract API.