### PR TITLE
Implement async callback

### DIFF
--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     _X = TypeVar("_X", bound=MGUI_SIMPLE_TYPES)
+    _V = TypeVar("_V")
     _M = TypeVar("_M", bound="MagicTemplate")
 
 defaults = {
@@ -666,23 +667,23 @@ class MagicTemplate(MutableSequence[_Comp], metaclass=_MagicTemplateMeta):
     # fmt: off
     @overload
     @classmethod
-    def vfield(cls, widget_type: type[_W], *, name: str | None = None, label: str | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[_W, Any]: ...  # noqa
+    def vfield(cls, widget_type: type[ValueWidget[_V]], *, name: str | None = None, label: str | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[_V]: ...  # noqa
 
     @overload
     @classmethod
-    def vfield(cls, annotation: type[_X], *, name: str | None = None, label: str | None = None, widget_type: str | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[ValueWidget, _X]: ...  # noqa
+    def vfield(cls, annotation: type[_X], *, name: str | None = None, label: str | None = None, widget_type: str | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[_X]: ...  # noqa
 
     @overload
     @classmethod
-    def vfield(cls, obj: _X, *, name: str | None = None, label: str | None = None, widget_type: str | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[ValueWidget, _X]: ...  # noqa
+    def vfield(cls, obj: _X, *, name: str | None = None, label: str | None = None, widget_type: str | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[_X]: ...  # noqa
 
     @overload
     @classmethod
-    def vfield(cls, obj: Any, *, name: str | None = None, label: str | None = None, widget_type: type[_W] = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[_W, Any]: ...  # noqa
+    def vfield(cls, obj: Any, *, name: str | None = None, label: str | None = None, widget_type: type[_W] = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[Any]: ...  # noqa
 
     @overload
     @classmethod
-    def vfield(cls, obj: Any, *, name: str | None = None, label: str | None = None, widget_type: str | type[Widget] | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[Widget, Any]: ...  # noqa
+    def vfield(cls, obj: Any, *, name: str | None = None, label: str | None = None, widget_type: str | type[Widget] | None = None, options: dict[str, Any] = {}, record: bool = True, ) -> MagicValueField[Any]: ...  # noqa
     # fmt: on
 
     @classmethod

--- a/magicclass/fields/_define.py
+++ b/magicclass/fields/_define.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Callable
 import inspect
 
-from magicclass.utils import argcount
+from magicclass.utils import argcount, thread_worker
 
 if TYPE_CHECKING:
     from magicclass._gui._base import MagicTemplate
@@ -16,6 +16,9 @@ def define_callback(self: Any, callback: Callable):
 def define_callback_gui(self: MagicTemplate, callback: Callable):
     """Define a callback function from a method of a magic-class."""
 
+    # if isinstance(callback, thread_worker):
+    #     return callback.with_func(define_callback_gui(self, callback.func))
+
     if callback.__qualname__.split("<locals>.")[-1].count(".") == 0:
         # not defined in a class
         params = list(inspect.signature(callback).parameters.values())
@@ -25,8 +28,8 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
 
         def _callback(v):
             with self.macro.blocked():
-                _func(v)
-            return None
+                out = _func(v)
+            return out
 
         return _callback
 
@@ -43,8 +46,8 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
 
             def _callback(v):
                 with self.macro.blocked():
-                    _func(v)
-                return None
+                    out = _func(v)
+                return out
 
             return _callback
 
@@ -60,8 +63,8 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
             _func = _normalize_argcount(getattr(current_self, funcname))
 
             with self.macro.blocked():
-                _func(v)
-            return None
+                out = _func(v)
+            return out
 
     else:
 
@@ -76,8 +79,8 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
             _func = _normalize_argcount(getattr(current_self, funcname))
 
             with self.macro.blocked():
-                _func(v)
-            return None
+                out = _func(v)
+            return out
 
     return _callback
 

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -538,7 +538,7 @@ class MagicField(_FieldObject, Generic[_W]):
                     if _running is not None:
                         _running.quit()
                     raise exc
-                yield
+                yield thread_worker.callback()  # empty callback
                 return out
 
             _afunc = thread_worker(

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -520,7 +520,7 @@ class MagicField(_FieldObject, Generic[_W]):
             _last_run = 0.0
 
             @wraps(fn)
-            def _func(self, *args, **kwargs):
+            def _func(self: MagicTemplate, *args, **kwargs):
                 nonlocal _running, _last_run
                 with threading.Lock():
                     f = _afunc.__get__(self)
@@ -531,9 +531,10 @@ class MagicField(_FieldObject, Generic[_W]):
                     _last_run = default_timer()
                 # call the original function
                 try:
-                    out = fn(self, *args, **kwargs)
-                    if isinstance(out, GeneratorType):
-                        out = yield from out
+                    with self.macro.blocked():
+                        out = fn(self, *args, **kwargs)
+                        if isinstance(out, GeneratorType):
+                            out = yield from out
                 except Exception as exc:
                     if _running is not None:
                         _running.quit()

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import inspect
+from types import GeneratorType
 from typing import (
     Any,
     TYPE_CHECKING,
@@ -9,6 +11,9 @@ from typing import (
     Generic,
 )
 from typing_extensions import Literal, _AnnotatedAlias
+import threading
+from functools import wraps
+import warnings
 from magicgui.widgets import create_widget, Widget
 from magicgui.widgets.bases import (
     ValueWidget,
@@ -30,12 +35,14 @@ from magicclass.signature import MagicMethodSignature
 from magicclass._gui.mgui_ext import Action, WidgetAction
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing_extensions import Self, ParamSpec
+    from magicclass.utils import thread_worker
     from magicclass._gui._base import MagicTemplate
     from magicclass._gui.mgui_ext import AbstractAction
 
     _M = TypeVar("_M", bound=MagicTemplate)
     _X = TypeVar("_X", bound=MGUI_SIMPLE_TYPES)
+    _P = ParamSpec("_P")
 
 
 class _FieldObject:
@@ -437,18 +444,91 @@ class MagicField(_FieldObject, Generic[_W]):
         """Set callback function to "ready to connect" state."""
         if not callable(func):
             raise TypeError("Cannot connect non-callable object")
+        elif inspect.isgeneratorfunction(func):
+            warnings.warn(
+                "Generator function is connected, which will not complete "
+                "as a callback.",
+                UserWarning,
+            )
         self._callbacks.append(func)
         return func
 
     def disconnect(self, func: Callable) -> None:
         """
         Disconnect callback from the field.
+
         This method does NOT disconnect callbacks from widgets that are
         already created.
         """
         i = self._callbacks.index(func)
         self._callbacks.pop(i)
         return None
+
+    @overload
+    def connect_async(
+        self,
+        func: Callable[_P, Any],
+        abort_prev: bool = False,
+    ) -> thread_worker[_P]:
+        ...
+
+    @overload
+    def connect_async(
+        self,
+        func: Literal[None],
+        abort_prev: bool = False,
+    ) -> Callable[[Callable[_P, Any]], thread_worker[_P]]:
+        ...
+
+    def connect_async(self, func=None, abort_prev=False):
+        """
+        Connect a callback function to be called asynchronously.
+
+        This method can be used similarly as ``connect`` but returns
+        a ``thread_worder`` object.
+
+        >>> @magicclass
+        >>> class A:
+        ...     x = field(int)
+        ...     @x.connect_async
+        ...     def _x_changed(self, v):
+        ...         time.sleep(1)
+        ...         return v
+        ...     @_x_changed.returned.connect
+        ...     def _x_returned(self, v):
+        ...         print(v)
+
+        Parameters
+        ----------
+        func : callable
+            The callback function
+        abort_prev : bool, default is False
+            If true, abort the previous call if it is still running.
+        """
+        from magicclass.utils import thread_worker
+
+        def _wrapper(fn):
+            _running = None
+
+            def _func(self, *args, **kwargs):
+                nonlocal _running
+                with threading.Lock():
+                    f = _afunc.__get__(self)
+                    if abort_prev:
+                        if _running is not None:
+                            _running.quit()
+                        _running = f._worker()
+                out = fn(self, *args, **kwargs)
+                if isinstance(out, GeneratorType):
+                    out = yield from out
+                yield
+                return out
+
+            _afunc = thread_worker(_func, force_async=True)
+            wraps(fn)(_afunc)
+            return self.connect(_afunc)
+
+        return _wrapper if func is None else _wrapper(func)
 
     # fmt: off
     @overload

--- a/magicclass/utils/qthreading/_callback.py
+++ b/magicclass/utils/qthreading/_callback.py
@@ -81,9 +81,11 @@ class CallbackList(Generic[_R1]):
 
 
 def _make_method(func, obj: BaseGui):
-    def f(*args, **kwargs):
+    def f(*args):
+        if args and isinstance(args[0], Callback):
+            return None
         with obj.macro.blocked():
-            out = func.__get__(obj)(*args, **kwargs)
+            out = func.__get__(obj)(*args)
         return out
 
     return f
@@ -91,7 +93,7 @@ def _make_method(func, obj: BaseGui):
 
 def _make_filtered_method(func, obj: BaseGui):
     def f(yielded):
-        if isinstance(yielded, NestedCallback):
+        if isinstance(yielded, (Callback, NestedCallback)):
             return None
         with obj.macro.blocked():
             out = func.__get__(obj)(yielded)

--- a/magicclass/utils/qthreading/_callback.py
+++ b/magicclass/utils/qthreading/_callback.py
@@ -48,7 +48,7 @@ class CallbackList(Generic[_R1]):
         return callback
 
     def disconnect(
-        self, callback: Callable[[Any, _R1], _R2] | Callable[[Any], _R2]
+        self, callback: Callable[[Any, _R1], _R2] | Callable[[Any], _R2] | None = None
     ) -> Callable[[Any, _R1], _R2] | Callable[[Any], _R2]:
         """
         Remove callback function from the callback list.
@@ -58,6 +58,9 @@ class CallbackList(Generic[_R1]):
         callback : Callable
             Callback function to be removed.
         """
+        if callback is None:
+            self._callbacks.clear()
+            return None
         self._callbacks.remove(callback)
         return callback
 

--- a/magicclass/utils/qthreading/_callback.py
+++ b/magicclass/utils/qthreading/_callback.py
@@ -119,7 +119,7 @@ class Callback(Generic[_P, _R1]):
         return self.__class__(partial(self._func, *args, **kwargs))
 
     @overload
-    def __get__(self, obj, type=None) -> Callback[..., _R1]:
+    def __get__(self, obj: Any, type=None) -> Callback[..., _R1]:
         ...
 
     @overload

--- a/magicclass/utils/qthreading/thread_worker.py
+++ b/magicclass/utils/qthreading/thread_worker.py
@@ -384,14 +384,14 @@ class thread_worker(Generic[_P]):
                     Aborted.raise_()
 
             if _is_non_blocking:
+                if not self._ignore_errors:
 
-                @worker.errored.connect
-                def _on_error(err: Exception):
-                    # NOTE: Exceptions are raised in other thread so context manager
-                    # cannot catch them. Macro has to be reactived here.
-                    gui._error_mode.cleanup_tb(err)
-                    gui._error_mode.get_handler()(err, parent=gui)
-                    if not self._ignore_errors:
+                    @worker.errored.connect
+                    def _on_error(err: Exception):
+                        # NOTE: Exceptions are raised in other thread so context manager
+                        # cannot catch them. Macro has to be reactived here.
+                        gui._error_mode.cleanup_tb(err)
+                        gui._error_mode.get_handler()(err, parent=gui)
                         raise err  # reraise
 
                 worker.start()

--- a/magicclass/utils/qthreading/thread_worker.py
+++ b/magicclass/utils/qthreading/thread_worker.py
@@ -16,6 +16,7 @@ from typing import (
 )
 from typing_extensions import ParamSpec
 import warnings
+import weakref
 
 from superqt.utils import create_worker, GeneratorWorker, FunctionWorker
 from qtpy.QtCore import Qt, QThread, QCoreApplication
@@ -63,6 +64,7 @@ class AsyncMethod(Protocol[_P, _R]):
         ...
 
     __thread_worker__: thread_worker[_P]
+    _worker: weakref.ReferenceType[FunctionWorker | GeneratorWorker]
 
     def arun(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         """
@@ -97,6 +99,7 @@ class thread_worker(Generic[_P]):
         *,
         ignore_errors: bool = False,
         progress: ProgressDict | bool | None = None,
+        force_async: bool = False,
     ) -> None:
         self._func: Callable[_P, _R] | None = None
         self._callback_dict_ = {
@@ -127,6 +130,7 @@ class thread_worker(Generic[_P]):
             progress.setdefault("pbar", None)
 
         self._progress: ProgressDict | None = progress
+        self._force_async = force_async
 
     @property
     def func(self) -> Callable[_P, _R]:
@@ -351,9 +355,9 @@ class thread_worker(Generic[_P]):
         @_async_method
         @wraps(self)
         def _create_worker(*args, **kwargs):
-            _is_non_blocking = (
-                self.button(gui).running and len(self._BLOCKING_SOURCES) == 0
-            )
+            _is_non_blocking = (self._force_async or self.button(gui).running) and len(
+                self._BLOCKING_SOURCES
+            ) == 0
             with gui.macro.blocked():
                 args, kwargs = self._validate_args(gui, args, kwargs)
 
@@ -371,7 +375,7 @@ class thread_worker(Generic[_P]):
             if self._progress:
                 self._init_pbar_post(pbar, worker)
 
-            if is_generator:
+            if is_generator and not self._force_async:
 
                 @worker.aborted.connect
                 def _on_abort():
@@ -390,7 +394,9 @@ class thread_worker(Generic[_P]):
                     if not self._ignore_errors:
                         raise err  # reraise
 
-                return worker.start()
+                worker.start()
+                _create_worker._worker = weakref.ref(worker)
+                return None
             else:
                 # If function is called from script, some events must get processed by
                 # the application while keep script stopping at each line of code.

--- a/magicclass/utils/qthreading/thread_worker.py
+++ b/magicclass/utils/qthreading/thread_worker.py
@@ -210,10 +210,10 @@ class thread_worker(Generic[_P]):
         return cb
 
     @staticmethod
-    def callback(callback: Callable | None = None) -> Callback:
+    def callback(callback: Callable[_P, _R] = lambda: None) -> Callback[_P, _R]:
         """Convert a callback function to a callback object."""
-        if callback is None:
-            return Callback(lambda: None)
+        if not callable(callback):
+            raise TypeError(f"{callback} is not callable.")
         return Callback(callback)
 
     @staticmethod

--- a/magicclass/utils/qthreading/thread_worker.py
+++ b/magicclass/utils/qthreading/thread_worker.py
@@ -210,8 +210,10 @@ class thread_worker(Generic[_P]):
         return cb
 
     @staticmethod
-    def callback(callback: Callable) -> Callback:
+    def callback(callback: Callable | None = None) -> Callback:
         """Convert a callback function to a callback object."""
+        if callback is None:
+            return Callback(lambda: None)
         return Callback(callback)
 
     @staticmethod

--- a/magicclass/utils/qthreading/thread_worker.py
+++ b/magicclass/utils/qthreading/thread_worker.py
@@ -272,12 +272,15 @@ class thread_worker(Generic[_P]):
 
     def __call__(self, *args, **kwargs):
         if self._func is None:
-            f = args[0]
-            self._func = f
-            wraps(f)(self)  # NOTE: __name__ etc. are updated here.
-            return self
+            return self.with_func(args[0])
         else:
             return self._func(*args, **kwargs)
+
+    def with_func(self, func: Callable[_P, _R]) -> thread_worker[_P]:
+        """Set the function."""
+        self._func = func
+        wraps(func)(self)  # NOTE: __name__ etc. are updated here.
+        return self
 
     @overload
     def __get__(self, gui: Literal[None], objtype=None) -> thread_worker[_P]:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -273,3 +273,22 @@ def test_async_callback_wrapped():
     with thread_worker.blocking_mode():
         ui.x = 1
         assert ui._val == (ui, 1)
+
+def test_async_callback_generator():
+    z = []
+    @magicclass
+    class A(MagicTemplate):
+        x = field(int)
+
+        @x.connect_async
+        def _callback_x(self):
+            time.sleep(0.05)
+            yield
+            z.append(0)
+            yield
+            z.append(1)
+            return
+    ui = A()
+    with thread_worker.blocking_mode():
+        ui.x.value = 1
+        assert z == [0, 1]

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,4 +1,6 @@
-from magicclass import magicclass, magicmenu, MagicTemplate, field, vfield
+from magicclass import magicclass, magicmenu, MagicTemplate, field, vfield, abstractapi
+from magicclass.utils import thread_worker
+import time
 from unittest.mock import MagicMock
 import pytest
 
@@ -196,3 +198,78 @@ def test_callback_outside_class():
     assert _cb0.x == 1
     assert _cb1.x == 4
     assert _cb2.x == 4
+
+def test_async_callback():
+    mock_x = MagicMock()
+    mock_y = MagicMock()
+    z = []
+
+    @magicclass
+    class A(MagicTemplate):
+        x = field(int)
+        y = vfield(str)
+
+        @x.connect_async
+        def _callback_x(self):
+            time.sleep(0.05)
+            mock_x()
+            return "x"
+
+        @y.connect_async
+        def _callback_y(self):
+            time.sleep(0.05)
+            mock_y()
+            return "y"
+
+        @_callback_x.returned.connect
+        @_callback_y.returned.connect
+        def _on_returned(self, v: str):
+            z.append(v)
+
+    ui = A()
+    with thread_worker.blocking_mode():
+        ui.x.value = 1
+        mock_x.assert_called_once()
+        assert z == ["x"]
+        ui.y = "zxcv"
+        mock_y.assert_called_once()
+        assert z == ["x", "y"]
+
+def test_async_callback_nested():
+    @magicclass
+    class A(MagicTemplate):
+        def __init__(self):
+            self._val = None
+
+        @magicclass
+        class B(MagicTemplate):
+            x = field(int)
+
+        @B.x.connect_async
+        def _x(self, v):
+            self._val = self, v
+
+    ui = A()
+    with thread_worker.blocking_mode():
+        ui.B.x.value = 1
+        assert ui._val == (ui, 1)
+
+def test_async_callback_wrapped():
+    @magicclass
+    class A(MagicTemplate):
+        def __init__(self):
+            self._val = None
+
+        @magicclass
+        class B(MagicTemplate):
+            x = abstractapi()
+
+        x = B.vfield(int)
+        @x.connect_async
+        def _x(self, v):
+            self._val = self, v
+
+    ui = A()
+    with thread_worker.blocking_mode():
+        ui.x = 1
+        assert ui._val == (ui, 1)


### PR DESCRIPTION
This PR adds `connect_async` method to `MagicField`.
Now users can easily implement async slider, non-blocking data loading etc.