### PR TITLE
Don't use callback level

### DIFF
--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -164,35 +164,6 @@ def check_override(cls: type):
         )
 
 
-def count_callback_levels(cls: type):
-    if cls.__mro__[1] is not MagicTemplate:
-        return
-    for name, attr in cls.__dict__.items():
-        if isinstance(attr, MagicField):
-            for cb in attr.callbacks:
-                cb_ns = cb.__qualname__.rsplit(".", maxsplit=1)[0]
-                if not hasattr(cb, "__qualname__"):
-                    continue
-                if cls.__qualname__.startswith(cb_ns):
-                    level = cls.__qualname__[len(cb_ns) :].count(".")
-                    cb.__magicclass_callback_level__ = level
-
-
-def init_sub_magicclass(cls: type):
-    check_override(cls)
-    if cls.__mro__[1] is not MagicTemplate:
-        return
-    for attr in cls.__dict__.values():
-        if isinstance(attr, MagicField):
-            for cb in attr.callbacks:
-                cb_ns = cb.__qualname__.rsplit(".", maxsplit=1)[0]
-                if not hasattr(cb, "__qualname__"):
-                    continue
-                if cls.__qualname__.startswith(cb_ns):
-                    level = cls.__qualname__[len(cb_ns) :].count(".")
-                    cb.__magicclass_callback_level__ = level
-
-
 _ANCESTORS: dict[tuple[int, int], MagicTemplate] = {}
 
 _T = TypeVar("_T", bound="MagicTemplate")
@@ -257,7 +228,7 @@ class MagicTemplate(MutableSequence[_Comp], metaclass=_MagicTemplateMeta):
     width: int
 
     def __init_subclass__(cls, **kwargs):
-        init_sub_magicclass(cls)
+        check_override(cls)
 
     @overload
     def __getitem__(self, key: int | str) -> _Comp:

--- a/magicclass/core.py
+++ b/magicclass/core.py
@@ -31,7 +31,7 @@ from magicclass._gui._base import (
     ErrorMode,
     defaults,
     MagicTemplate,
-    init_sub_magicclass,
+    check_override,
     convert_attributes,
 )
 from magicclass._gui import ContextMenuGui, MenuGui, ToolBarGui
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from magicclass.help import HelpWidget
     from macrokit import Macro
 
-_BASE_CLASS_SUFFIX = ".base"
+_BASE_CLASS_SUFFIX = ":base"
 
 _TYPE_MAP: dict[WidgetType, type[ClassGuiBase]] = {
     WidgetType.none: ClassGui,
@@ -156,7 +156,7 @@ def magicclass(
         class_gui = _TYPE_MAP[widget_type]
 
         if not issubclass(cls, MagicTemplate):
-            init_sub_magicclass(cls)
+            check_override(cls)
 
         # get class attributes first
         doc = cls.__doc__
@@ -282,7 +282,7 @@ def magiccontext(
             raise TypeError(f"magicclass can only wrap classes, not {type(cls)}")
 
         if not issubclass(cls, MagicTemplate):
-            init_sub_magicclass(cls)
+            check_override(cls)
 
         # get class attributes first
         doc = cls.__doc__
@@ -407,7 +407,7 @@ def _call_magicmenu(
             raise TypeError(f"magicclass can only wrap classes, not {type(cls)}")
 
         if not issubclass(cls, MagicTemplate):
-            init_sub_magicclass(cls)
+            check_override(cls)
 
         # get class attributes first
         doc = cls.__doc__

--- a/magicclass/fields/_define.py
+++ b/magicclass/fields/_define.py
@@ -51,14 +51,20 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
 
             return _callback
 
-    if hasattr(callback, "__magicclass_callback_level__"):
-        level = callback.__magicclass_callback_level__
-        assert isinstance(level, int) and level >= 0
+    if isinstance(_qn := getattr(callback, "__qualname__", None), str):
+        cb_level = _qn.count(".") - 1
+        cls_level = self.__class__.__qualname__.count(".")
+        level_dif = cls_level - cb_level
+        if level_dif < 0:
+            raise ValueError(
+                f"Callback {_qn} is trying to be connected to {cls_level}, which "
+                "is in a upper level."
+            )
 
         def _callback(v):
             # search for parent instances that have the same name.
             current_self = self
-            for _ in range(level):
+            for _ in range(level_dif):
                 current_self = current_self.__magicclass_parent__
             _func = _normalize_argcount(getattr(current_self, funcname))
 


### PR DESCRIPTION
Using `__magicclass_callback_level` makes the inconsistency when classes of different level trying to connect the same callback function.
This PR gives an alternative solution.