### PR TITLE
Use `location=` for parent/child connection

### DIFF
--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -35,7 +35,6 @@ from .fields import (
     magicproperty,
     FieldGroup,
     HasFields,
-    dataclass_gui,
 )
 from ._gui._base import defaults, MagicTemplate, PopUpMode
 from ._gui.keybinding import Key

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -147,24 +147,7 @@ class ClassGuiBase(BaseGui[Widget]):
                 continue
 
             try:
-                if isinstance(attr, type):
-                    # Nested magic-class
-                    widget = attr()
-                    object.__setattr__(self, name, widget)
-
-                elif isinstance(attr, MagicField):
-                    # If MagicField is given by field() function.
-                    widget = self._create_widget_from_field(name, attr)
-                    if not widget.tooltip:
-                        widget.tooltip = _tooltips.attributes.get(name, "")
-
-                elif isinstance(attr, FunctionGui):
-                    widget = attr.copy()
-                    widget[0].bind(self)  # bind self to the first argument
-
-                else:
-                    # convert class method into instance method
-                    widget = getattr(self, name, None)
+                widget = self._convert_an_attribute_into_widget(name, attr, _tooltips)
 
                 if isinstance(widget, BaseGui):
                     connect_magicclasses(self, widget, name)

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -89,18 +89,6 @@ class ClassGuiBase(BaseGui[Widget]):
         fld.name = fld.name or name
         widget = fld.get_widget(self)
 
-        if isinstance(widget, BaseGui):
-            widget.__magicclass_parent__ = self
-            self.__magicclass_children__.append(widget)
-            widget._my_symbol = Symbol(name)
-
-        elif isinstance(fld, BoxMagicField):
-            for wdt in widget:
-                if isinstance(wdt, BaseGui):
-                    wdt.__magicclass_parent__ = self
-                    self.__magicclass_children__.append(wdt)
-                    wdt._my_symbol = Symbol(name)
-
         if isinstance(widget, (ValueWidget, ContainerWidget)):
             # If the field has callbacks, connect it to the newly generated widget.
             if fld.record:
@@ -148,9 +136,6 @@ class ClassGuiBase(BaseGui[Widget]):
 
             try:
                 widget = self._convert_an_attribute_into_widget(name, attr, _tooltips)
-
-                if isinstance(widget, BaseGui):
-                    connect_magicclasses(self, widget, name)
 
                 if isinstance(widget, MenuGui):
                     # Add menubar to container

--- a/magicclass/_gui/menu_gui.py
+++ b/magicclass/_gui/menu_gui.py
@@ -92,8 +92,6 @@ class MenuGuiBase(ContainerLikeGui):
                 widget = self._convert_an_attribute_into_widget(name, attr, _tooltips)
 
                 if isinstance(widget, BaseGui):
-                    connect_magicclasses(self, widget, name)
-
                     if isinstance(widget, MenuGuiBase):
                         widget.native.setParent(
                             self.native, widget.native.windowFlags()

--- a/magicclass/_gui/menu_gui.py
+++ b/magicclass/_gui/menu_gui.py
@@ -89,25 +89,9 @@ class MenuGuiBase(ContainerLikeGui):
                 continue
 
             try:
-                if isinstance(attr, type):
-                    # Nested magic-menu
-                    widget = attr()
-                    object.__setattr__(self, name, widget)
+                widget = self._convert_an_attribute_into_widget(name, attr, _tooltips)
 
-                elif isinstance(attr, MagicField):
-                    widget = self._create_widget_from_field(name, attr)
-                    if not widget.tooltip:
-                        widget.tooltip = _tooltips.attributes.get(name, "")
-
-                else:
-                    # convert class method into instance method
-                    widget = getattr(self, name, None)
-
-                if isinstance(widget, FunctionGui):
-                    widget = attr.copy()
-                    widget[0].bind(self)  # bind self to the first argument
-
-                elif isinstance(widget, BaseGui):
+                if isinstance(widget, BaseGui):
                     connect_magicclasses(self, widget, name)
 
                     if isinstance(widget, MenuGuiBase):

--- a/magicclass/_gui/toolbar.py
+++ b/magicclass/_gui/toolbar.py
@@ -127,25 +127,9 @@ class ToolBarGui(ContainerLikeGui):
                 continue
 
             try:
-                if isinstance(attr, type):
-                    # Nested magic-menu
-                    widget = attr()
-                    object.__setattr__(self, name, widget)
+                widget = self._convert_an_attribute_into_widget(name, attr, _tooltips)
 
-                elif isinstance(attr, MagicField):
-                    widget = self._create_widget_from_field(name, attr)
-                    if not widget.tooltip:
-                        widget.tooltip = _tooltips.attributes.get(name, "")
-
-                else:
-                    # convert class method into instance method
-                    widget = getattr(self, name, None)
-
-                if isinstance(widget, FunctionGui):
-                    widget = attr.copy()
-                    widget[0].bind(self)  # bind self to the first argument
-
-                elif isinstance(widget, BaseGui):
+                if isinstance(widget, BaseGui):
                     connect_magicclasses(self, widget, name)
 
                     if isinstance(widget, MenuGui):

--- a/magicclass/_gui/toolbar.py
+++ b/magicclass/_gui/toolbar.py
@@ -130,8 +130,6 @@ class ToolBarGui(ContainerLikeGui):
                 widget = self._convert_an_attribute_into_widget(name, attr, _tooltips)
 
                 if isinstance(widget, BaseGui):
-                    connect_magicclasses(self, widget, name)
-
                     if isinstance(widget, MenuGui):
                         tb = ToolButtonPlus(widget.name)
                         tb.set_menu(widget.native)

--- a/magicclass/_gui/utils.py
+++ b/magicclass/_gui/utils.py
@@ -43,16 +43,19 @@ def copy_class(cls: _C, ns: str, name: str) -> _C:
     type
         Copied class object.
     """
+    from magicclass.wrappers import abstractapi
+    from magicclass.utils.qthreading import thread_worker
+
     namespace = {}
     qualname = f"{ns}.{name}"
     for key, attr in cls.__dict__.items():
-        if isinstance(attr, FunctionType):
+        if isinstance(attr, (FunctionType, abstractapi, thread_worker)):
             if attr.__qualname__.split("<locals>.")[-1].count(".") == 0:
                 pass
             else:
                 attr.__qualname__ = f"{qualname}.{key}"
         elif isinstance(attr, type):
-            attr = copy_class(attr, qualname, attr.__name__)
+            attr = copy_class(attr, qualname, attr.__qualname__.split(".")[-1])
         namespace[key] = attr
 
     out = type(cls.__name__, cls.__bases__, namespace)

--- a/magicclass/_gui/utils.py
+++ b/magicclass/_gui/utils.py
@@ -49,6 +49,8 @@ def copy_class(cls: _C, ns: str, name: str) -> _C:
     namespace = {}
     qualname = f"{ns}.{name}"
     for key, attr in cls.__dict__.items():
+        if key == ("__original_class__"):
+            continue
         if isinstance(attr, (FunctionType, abstractapi, thread_worker)):
             if attr.__qualname__.split("<locals>.")[-1].count(".") == 0:
                 pass
@@ -57,9 +59,9 @@ def copy_class(cls: _C, ns: str, name: str) -> _C:
         elif isinstance(attr, type):
             attr = copy_class(attr, qualname, attr.__qualname__.split(".")[-1])
         namespace[key] = attr
-
     out = type(cls.__name__, cls.__bases__, namespace)
     out.__qualname__ = qualname
+    out.__original_class__ = getattr(cls, "__original_class__", cls)
     return out
 
 

--- a/magicclass/core.py
+++ b/magicclass/core.py
@@ -530,7 +530,7 @@ def get_button(ui: MagicTemplate | ModuleType, name: str | None = None) -> Click
 
         opt = get_additional_option(getattr(ui, name), "into", None)
         if opt is not None:
-            for child_instance in ui._iter_child_magicclasses():
+            for _, child_instance in ui._iter_child_magicclasses():
                 _name = child_instance.__class__.__name__
                 if _name == opt:
                     widget = child_instance[name]

--- a/magicclass/ext/pyqtgraph/graph_items.py
+++ b/magicclass/ext/pyqtgraph/graph_items.py
@@ -28,6 +28,7 @@ _SYMBOL_MAP = {
 
 class LayerItem:
     native: pg.GraphicsItem
+    name: str
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__} '{self.name}'"

--- a/magicclass/fields/_define.py
+++ b/magicclass/fields/_define.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Callable
 import inspect
 
-from magicclass.utils import argcount, thread_worker
+from magicclass.utils import argcount, get_level
 
 if TYPE_CHECKING:
     from magicclass._gui._base import MagicTemplate
@@ -17,6 +17,7 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
     """Define a callback function from a method of a magic-class."""
 
     if callback.__qualname__.split("<locals>.")[-1].count(".") == 0:
+        # if get_level(callback) <= 0:
         # not defined in a class
         params = list(inspect.signature(callback).parameters.values())
         if len(params) > 0 and params[0].name == "self":
@@ -49,6 +50,8 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
             return _callback
 
     if isinstance(_qn := getattr(callback, "__qualname__", None), str):
+        # cb_level = get_level(callback)
+        # cls_level = get_level(self.__class__)
         cb_level = _qn.count(".") - 1
         cls_level = self.__class__.__qualname__.count(".")
         level_dif = cls_level - cb_level

--- a/magicclass/fields/_define.py
+++ b/magicclass/fields/_define.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Callable
 import inspect
 
-from magicclass.utils import argcount, get_level
+from magicclass.utils import argcount
 
 if TYPE_CHECKING:
     from magicclass._gui._base import MagicTemplate
@@ -17,7 +17,6 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
     """Define a callback function from a method of a magic-class."""
 
     if callback.__qualname__.split("<locals>.")[-1].count(".") == 0:
-        # if get_level(callback) <= 0:
         # not defined in a class
         params = list(inspect.signature(callback).parameters.values())
         if len(params) > 0 and params[0].name == "self":
@@ -50,8 +49,6 @@ def define_callback_gui(self: MagicTemplate, callback: Callable):
             return _callback
 
     if isinstance(_qn := getattr(callback, "__qualname__", None), str):
-        # cb_level = get_level(callback)
-        # cls_level = get_level(self.__class__)
         cb_level = _qn.count(".") - 1
         cls_level = self.__class__.__qualname__.count(".")
         level_dif = cls_level - cb_level

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -542,8 +542,7 @@ class MagicField(_FieldObject, Generic[_W]):
             if isinstance(fn, thread_worker):
                 # this case is needed when multiple @connect_async are used
                 # for the same function.
-                self.connect(fn.replace(force_async=True))
-                return fn
+                return self.connect(fn)
             # non-local variables
             _running: WorkerBase | None = None  # the running worker
             _last_run = 0.0  # last time the worker was started
@@ -610,8 +609,7 @@ class MagicField(_FieldObject, Generic[_W]):
                 force_async=True,
                 ignore_errors=ignore_errors,
             )
-            self.connect(_afunc)
-            return _afunc.replace(force_async=False)
+            return self.connect(_afunc)
 
         return _wrapper if func is None else _wrapper(func)
 

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -215,9 +215,8 @@ class MagicField(_FieldObject, Generic[_W]):
 
     def with_widget_type(self, widget_type: type[Widget]):
         """Method to add widget type to the field."""
-        new = self.copy()
-        new._widget_type = widget_type
-        return new
+        self._widget_type = widget_type
+        return self
 
     @property
     def __signature__(self):
@@ -812,7 +811,7 @@ def field(
     widget_type: str | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicField[_M]:
     ...
 
@@ -825,7 +824,7 @@ def field(
     label: str | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicField[_W]:
     ...
 
@@ -839,7 +838,7 @@ def field(
     widget_type: str | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicField[ValueWidget[_X]]:
     ...
 
@@ -853,7 +852,7 @@ def field(
     widget_type: str | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicField[ValueWidget[_X]]:
     ...
 
@@ -867,7 +866,7 @@ def field(
     widget_type: type[_W] = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicField[_W]:
     ...
 
@@ -881,7 +880,7 @@ def field(
     widget_type: str | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicField[Widget]:
     ...
 
@@ -894,7 +893,7 @@ def field(
     widget_type: str | type[Widget] | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicField[Widget]:
     ...
 
@@ -954,7 +953,7 @@ def vfield(
     label: str | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicValueField[_V]:
     ...
 
@@ -967,7 +966,7 @@ def vfield(
     label: str | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicValueField[Any]:
     ...
 
@@ -981,7 +980,7 @@ def vfield(
     widget_type: str | type[Widget] | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicValueField[_X]:
     ...
 
@@ -995,7 +994,7 @@ def vfield(
     widget_type: str | type[Widget] | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicValueField[_X]:
     ...
 
@@ -1009,7 +1008,7 @@ def vfield(
     widget_type: type[ValueWidget[_V]] = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicValueField[_V]:
     ...
 
@@ -1023,7 +1022,7 @@ def vfield(
     widget_type: str | type[Widget] | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicValueField[Any]:
     ...
 
@@ -1036,20 +1035,20 @@ def vfield(
     widget_type: str | type[Widget] | None = None,
     options: dict[str, Any] = {},
     record: bool = True,
-    location: MagicTemplate | None = None,
+    location: type[MagicTemplate] | MagicField | None = None,
 ) -> MagicValueField[Any]:
     ...
 
 
 def vfield(
-    obj: Any = Undefined,
+    obj=Undefined,
     *,
-    name: str | None = None,
-    label: str | None = None,
-    widget_type: str | None = None,
-    options: dict[str, Any] = {},
-    record: bool = True,
-    location: MagicTemplate | None = None,
+    name=None,
+    label=None,
+    widget_type=None,
+    options={},
+    record=True,
+    location=None,
 ) -> MagicValueField[Widget, Any]:
     """
     Make a MagicValueField object.

--- a/magicclass/utils/__init__.py
+++ b/magicclass/utils/__init__.py
@@ -3,6 +3,7 @@ from ._functions import (
     Tooltips,
     get_signature,
     argcount,
+    get_level,
     is_instance_method,
     method_as_getter,
     eval_attribute,

--- a/magicclass/utils/_functions.py
+++ b/magicclass/utils/_functions.py
@@ -146,16 +146,16 @@ def method_as_getter(self: BaseGui, getter: Callable):
     if _LOCALS in qualname:
         qualname = qualname.split(_LOCALS)[-1]
     *clsnames, funcname = qualname.split(".")
-    ins = self
-    self_cls = ins.__class__.__qualname__.split(".")[-1]
+    self_cls = self.__class__.__qualname__.split(".")[-1]
     if self_cls not in clsnames:
         ns = ".".join(clsnames)
         raise ValueError(
+            f"{self_cls} not in {clsnames!r}. "
             f"Method {funcname} is in namespace {ns!r}, so it is invisible "
             f"from class {self.__class__.__qualname__!r}."
         )
     i = clsnames.index(self_cls) + 1
-
+    ins = self
     for clsname in clsnames[i:]:
         ins = getattr(ins, clsname)
 

--- a/magicclass/utils/_functions.py
+++ b/magicclass/utils/_functions.py
@@ -126,6 +126,13 @@ def argcount(func: Callable) -> int:
     return nargs
 
 
+def get_level(f: Callable | type) -> int:
+    level = f.__qualname__.split(_LOCALS)[-1].count(".")
+    if callable(f):
+        return level - 1
+    return level
+
+
 _LOCALS = "<locals>."
 
 

--- a/magicclass/wrappers/_abstractapi.py
+++ b/magicclass/wrappers/_abstractapi.py
@@ -47,7 +47,7 @@ class abstractapi(Callable):
             self.__name__ = "unknown"
         self._resolved = False
         self._location = location
-        if location is not None:
+        if location is not None and not hasattr(self, "__signature__"):
             self.__signature__ = inspect.Signature([])
 
     def __call__(self, *args, **kwargs) -> NoReturn:
@@ -61,7 +61,8 @@ class abstractapi(Callable):
         api = getattr(self._location, name, None)
         if isinstance(api, abstractapi):
             api.resolve()
-            api.__signature__ = inspect.Signature([])
+            if not hasattr(self, "__signature__"):
+                api.__signature__ = inspect.Signature([])
 
     def __get__(self, instance, owner=None) -> abstractapi:
         """Always return the same object."""

--- a/magicclass/wrappers/_abstractapi.py
+++ b/magicclass/wrappers/_abstractapi.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
+import inspect
 from typing import Callable, TYPE_CHECKING
 import functools
 from magicclass._exceptions import AbstractAPIError
 
 if TYPE_CHECKING:
     from typing import NoReturn
+    from magicclass._gui import MagicTemplate
+    from magicclass.fields import MagicField
 
 
 class abstractapi(Callable):
@@ -28,7 +31,12 @@ class abstractapi(Callable):
     ...         print(i)  # do something
     """
 
-    def __init__(self, func: Callable | None = None):
+    def __init__(
+        self,
+        func: Callable | None = None,
+        *,
+        location: type[MagicTemplate] | MagicField | None = None,
+    ):
         if func is not None:
             if not callable(func) or isinstance(func, type):
                 raise TypeError("abstractapi can only be used on functions and methods")
@@ -38,6 +46,9 @@ class abstractapi(Callable):
         else:
             self.__name__ = "unknown"
         self._resolved = False
+        self._location = location
+        if location is not None:
+            self.__signature__ = inspect.Signature([])
 
     def __call__(self, *args, **kwargs) -> NoReturn:
         raise AbstractAPIError(
@@ -47,6 +58,10 @@ class abstractapi(Callable):
     def __set_name__(self, owner: type, name: str):
         self.__name__ = name
         self.__qualname__ = f"{owner.__qualname__}.{name}"
+        api = getattr(self._location, name, None)
+        if isinstance(api, abstractapi):
+            api.resolve()
+            api.__signature__ = inspect.Signature([])
 
     def __get__(self, instance, owner=None) -> abstractapi:
         """Always return the same object."""
@@ -68,3 +83,14 @@ class abstractapi(Callable):
         if not self._resolved:
             raise AbstractAPIError(f"{self!r} is not redefined in the parent class.")
         return None
+
+    def get_location(self) -> type[MagicTemplate] | None:
+        loc = self._location
+        if loc is None:
+            return None
+
+        from magicclass.fields import MagicField
+
+        if isinstance(loc, MagicField):
+            return loc.constructor
+        return loc

--- a/magicclass/wrappers/_misc.py
+++ b/magicclass/wrappers/_misc.py
@@ -10,6 +10,7 @@ from magicclass.signature import get_additional_option, upgrade_signature
 
 if TYPE_CHECKING:
     from magicclass._gui import MagicTemplate
+    from magicclass.fields import MagicField
 
 _F = TypeVar("_F", bound=Callable)
 
@@ -94,7 +95,7 @@ def set_design(
     max_height: int | None = None,
     text: str | None = None,
     icon: str | None = None,
-    location: MagicTemplate | None = None,
+    location: MagicTemplate | MagicField | None = None,
     font_size: int | None = None,
     font_family: int | None = None,
     font_color: Color | None = None,

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -307,7 +307,7 @@ def test_async_callback_wrapped():
         class B(MagicTemplate):
             x = abstractapi()
 
-        x = B.vfield(int)
+        x = vfield(int, location=B)
         @x.connect_async
         def _x(self, v):
             self._val = self, v

--- a/tests/test_wraps.py
+++ b/tests/test_wraps.py
@@ -175,8 +175,8 @@ def test_wrapped_field():
         class B:
             a = abstractapi()
             b = abstractapi()
-        a = B.field(int)
-        b = B.field(str)
+        a = field(int, location=B)
+        b = field(str, location=B)
 
     ui = A()
     assert ui.B[0].widget_type == "SpinBox"
@@ -203,8 +203,8 @@ def test_wrapped_vfield():
         class B:
             a = abstractapi()
             b = abstractapi()
-        a = B.vfield(int)
-        b = B.vfield(str)
+        a = vfield(int, location=B)
+        b = vfield(str, location=B)
 
     ui = A()
     assert ui.B[0].widget_type == "SpinBox"


### PR DESCRIPTION
Closes #124 

`<class name>.wraps` and `<class name>.field` are kind of inconsistent.
Moving the location of widgets are now refactored as `location=` keyword argument.

- `@set_design(location=X)` instead of `@X.wraps`.
- `field(..., location=X)` instead of `X.field(...)`.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added `location` parameter to `field` and `vfield` functions for specifying the location of fields.
- Introduced `get_level` function to determine the level of a function in the class hierarchy.

**Bug Fixes:**
- Fixed a bug in `method_as_getter` function where it was not correctly identifying the class name for nested classes.

**Refactor:**
- Refactored `_convert_attributes_into_widgets` method in `menu_gui.py` and `toolbar.py` for improved modularity and readability.
- Updated `abstractapi` class to handle a new optional `location` argument.

**Test:**
- Added new test functions `test_wrapped_with_external_field` and `test_wrapped_with_external_field_via_field` in `test_bind.py`.
- Updated test cases in `test_callbacks.py` and `test_wraps.py` to reflect changes in `field` and `vfield` functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->