### PR TITLE
fix using magic-classes in field

### DIFF
--- a/examples/use_menubar.py
+++ b/examples/use_menubar.py
@@ -1,4 +1,4 @@
-from magicclass import magicclass, magicmenu, set_options, abstractapi
+from magicclass import magicclass, magicmenu, set_options, abstractapi, field
 from magicgui.widgets import Image
 from pathlib import Path
 from skimage.io import imread, imsave
@@ -53,7 +53,7 @@ class Main:
         out = sobel(self.image.value)
         self.image.value = out
 
-    image = Image()
+    image = field(Image)
 
 if __name__ == "__main__":
     ui = Main()

--- a/magicclass/_app.py
+++ b/magicclass/_app.py
@@ -23,6 +23,13 @@ def gui_qt():
     return None
 
 
+def gui_qt_is_active() -> bool:
+    """True only if "%gui qt" magic is called in ipython kernel."""
+    shell = get_shell()
+
+    return shell and shell.active_eventloop == "qt"
+
+
 def get_app():
     """Get QApplication."""
     gui_qt()
@@ -36,4 +43,5 @@ def get_app():
 
 def run_app():
     """Start the event loop."""
-    return get_app().exec_()
+    if not gui_qt_is_active():
+        return get_app().exec_()

--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -765,7 +765,6 @@ class MagicTemplate(
                             title = Separator(
                                 orientation="horizontal", title=text, button=True
                             )
-                            # TODO: should remove mgui from self?
                             title.btn_clicked.connect(mgui.hide)
                             mgui.insert(0, title)
                     mgui._initialized_for_magicclass = True
@@ -1264,13 +1263,6 @@ def convert_attributes(
             _isfunc = callable(obj)
             if isinstance(obj, _MagicTemplateMeta):
                 new_attr = copy_class(obj, cls.__qualname__, name=name)
-            elif isinstance(obj, MagicField) and isinstance(
-                obj.constructor, _MagicTemplateMeta
-            ):
-                obj._constructor = copy_class(
-                    obj.constructor, cls.__qualname__, name=name
-                )
-                new_attr = obj
             elif name.startswith("_") or isinstance(obj, _pass) or not _isfunc:
                 # private method, non-action-like object, not-callable object are passed.
                 new_attr = obj

--- a/magicclass/_gui/_macro.py
+++ b/magicclass/_gui/_macro.py
@@ -277,7 +277,7 @@ class MacroEdit(TabbedContainer):
         """Run macro."""
         parent = self._search_parent_magicclass()
         ns = {Symbol.var("ui"): parent}
-        with parent._error_mode.raise_with_handler(self):
+        with parent._error_mode.raise_with_handler(parent):
             if self._attribute_check:
                 strs = [f"- {exc}" for exc in check_attributes(code, ns)]
                 if strs:

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -335,14 +335,14 @@ class ClassGuiBase(BaseGui):
                 w.reset_choices()
         return None
 
-    def show(self, run: bool = False) -> None:
+    def show(self, run: bool = True) -> None:
         """
         Show GUI. If any of the parent GUI is a dock widget in napari, then this
         will also show up as a dock widget (floating if in popup mode).
 
         Parameters
         ----------
-        run : bool, default False
+        run : bool, default True
             If true, application gets executed.
         """
         mcls_parent = self.__magicclass_parent__

--- a/magicclass/_gui/utils.py
+++ b/magicclass/_gui/utils.py
@@ -49,7 +49,7 @@ def copy_class(cls: _C, ns: str, name: str) -> _C:
     namespace = {}
     qualname = f"{ns}.{name}"
     for key, attr in cls.__dict__.items():
-        if key == ("__original_class__"):
+        if key == "__original_class__":
             continue
         if isinstance(attr, (FunctionType, abstractapi, thread_worker)):
             if attr.__qualname__.split("<locals>.")[-1].count(".") == 0:

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -354,8 +354,8 @@ class MagicField(_FieldObject, Generic[_W]):
         """Make a function that get the value of Widget or Action."""
         return lambda w: self._guis[id(obj)].value
 
-    def as_remote_getter(self, obj: Any):
-        """Called when a MagicField is used in Bound method."""
+    def as_remote_getter(self, obj: MagicTemplate):
+        """Called when a MagicField is used in "bind"."""
         qualname = self._parent_class.__qualname__
         _LOCALS = "<locals>."
         if _LOCALS in qualname:
@@ -368,17 +368,21 @@ class MagicField(_FieldObject, Generic[_W]):
             if objname not in clsnames:
                 ns = ".".join(clsnames)
                 raise ValueError(
-                    f"{obj.__class__.__name__!r} not in {clsnames!r}. "
+                    f"{objname!r} not in {clsnames!r}. "
                     f"Method {self.name!r} is in namespace {ns!r}, so it is invisible "
                     f"from magicclass {obj.__class__.__qualname__!r}."
                 )
             i = clsnames.index(objname) + 1
+            # class A:
+            #   class B:
+            #     f = field(...)
+            #   def func(self, a: Bound[B.f]): ...
             ins = obj
             for clsname in clsnames[i:]:
                 ins = getattr(ins, clsname, ins)
 
-            # Now, ins is an instance of parent class.
-            # Extract correct widget from MagicField
+            # Now, ins is an instance of parent class. Extract correct widget from
+            # MagicField
             _field_widget = self.get_widget(ins)
             if not hasattr(_field_widget, "value"):
                 raise TypeError(

--- a/magicclass/testing/_gui_test.py
+++ b/magicclass/testing/_gui_test.py
@@ -67,7 +67,12 @@ def _qualname(obj: MethodType | type):
 
 
 def check_function_gui_buildable(ui: MagicTemplate, skips: list = []):
-    """Assert that all methods in ``ui`` can be built into GUI."""
+    """
+    Assert that all methods in ``ui`` can be built into GUI.
+
+    This function can also detect if any of the annotations of a method uses "bind" or
+    "choices" that results in an error.
+    """
 
     failed = []
     for method in _iter_method_with_button(ui):

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -1,3 +1,4 @@
+from typing import Annotated
 from magicclass import magicclass, set_options, field, vfield, get_function_gui
 from magicgui.widgets import Select
 import pytest
@@ -111,6 +112,21 @@ def test_field():
     assert ui[0].choices == (3,)
     assert ui[1].choices == (3,)
     assert ui[2].choices == (0, 1)
+
+def test_field_in_other_class():
+    @magicclass
+    class Sub:
+        def _get_choices(self, w=None):
+            return [0, 1]
+
+        def f(self, x: Annotated[int, {"choices": _get_choices}]):
+            pass
+
+    @magicclass
+    class A:
+        sub = field(Sub)
+
+    ui = A()
 
 def test_multi_gui():
     @magicclass

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing_extensions import Annotated
 from magicclass import magicclass, set_options, field, vfield, get_function_gui
 from magicgui.widgets import Select
 import pytest

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -796,3 +796,29 @@ def test_class_annotation():
     ui = A()
     assert ui.x.max == 10
     assert ui["y"].widget_type == "FloatSlider"
+
+def test_using_same_class():
+    @magicclass(layout="horizontal", labels=False)
+    class Laser:
+        bar = vfield(0, widget_type="ProgressBar").with_options(min=0, max=100)
+        percent = vfield(0, widget_type="SpinBox").with_options(min=0, max=100)
+
+        def apply(self, value: Annotated[int, {"bind": percent}]):
+            """Apply laser power."""
+            self.bar = self.percent = value
+
+    @magicclass(labels=False)
+    class LaserControl:
+        laser_blue = field(Laser)
+        laser_green = field(Laser)
+        laser_red = field(Laser)
+
+    ui = LaserControl()
+
+    ui.laser_blue.percent = 15
+    ui.laser_blue["apply"].changed()
+    assert ui.laser_blue.bar == 15
+    assert ui.laser_green.bar == 0
+    assert ui.laser_red.bar == 0
+    ui.laser_green["apply"].changed()
+    ui.laser_red["apply"].changed()


### PR DESCRIPTION
There were redundant copy during magicclass construction, which caused wrong reference.
This PR also fixes #131.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to check if the "%gui qt" magic is active in the IPython kernel.
  - Added new test functions to validate field choices and class attribute behaviors.

- **Enhancements**
  - Improved image data handling within the `Main` class.
  - Updated the default behavior of the `show` method to run by default.

- **Refactor**
  - Changed parameter type in `as_remote_getter` for better context usage.
  - Streamlined error handling in the `_execute` method of macros.
  - Optimized conditional logic in the `convert_attributes` function and the `copy_class` utility.

- **Bug Fixes**
  - Fixed the condition for `key` comparison in the `copy_class` function.

- **Documentation**
  - Expanded docstrings for clarity on method annotations and updated exception messages.

- **Style**
  - Removed an obsolete TODO comment.
  - Revised comments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->