### PR TITLE
update 3d canvas to latest vedo

### DIFF
--- a/examples/use_click.py
+++ b/examples/use_click.py
@@ -1,8 +1,8 @@
+import numpy as np
+from scipy.signal import medfilt
 from magicclass import magicclass, field
 from magicclass.utils import click
 from magicclass.widgets import Figure
-import numpy as np
-from scipy.signal import medfilt
 
 # `click` is useful when functions should be called in certain order.
 # In following example, random data must be generated before applying filter.
@@ -11,7 +11,7 @@ from scipy.signal import medfilt
 class A:
     def __init__(self):
         self._data = None
-        self._filtrated = None
+        self._filtered = None
 
     @click(enables="apply_filter")
     def generate_data(self, size: int = 200):
@@ -21,14 +21,14 @@ class A:
     @click(enables="plot_data", disables="apply_filter", enabled=False)
     def apply_filter(self, width: int = 3):
         """Apply median filter."""
-        self._filtrated = medfilt(self._data, kernel_size=width)
+        self._filtered = medfilt(self._data, kernel_size=width)
 
     @click(enabled=False)
     def plot_data(self):
         """Plot the results."""
         self.plt.cla()
         self.plt.plot(self._data, label="original data")
-        self.plt.plot(self._filtrated, label="filtrated data")
+        self.plt.plot(self._filtered, label="filtered data")
         self.plt.legend()
 
     plt = field(Figure)

--- a/examples/vedo_ex1.py
+++ b/examples/vedo_ex1.py
@@ -1,0 +1,32 @@
+import numpy as np
+from magicclass import magicclass, field
+from magicclass.ext.vtk import VedoCanvas
+import vedo
+
+@magicclass
+class VedoViewerUI:
+    canvas = field(VedoCanvas)
+
+ui = VedoViewerUI()
+
+coords = np.random.randn(1000, 3)
+data = np.cos(coords[:,1])
+
+# create a points object and a set of axes
+points = vedo.Points(coords)
+points.cmap("viridis", data).add_scalarbar3d()
+axes = vedo.Axes(points, c="white")
+
+# create a histogram of data
+histo = vedo.pyplot.histogram(
+    data, 
+    bins=10, 
+    c="viridis",
+    title="", xtitle="", ytitle="",
+).clone2d("bottom-right", 0.25)
+
+# add the points and axes to the plotter
+ui.canvas.plotter.add([points, axes, histo]).reset_camera()
+
+# start the UI
+ui.show()

--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -73,6 +73,7 @@ __all__ = [
     "MagicTemplate",
     "PopUpMode",
     "Icon",
+    # "VtkCanvas",
 ]
 
 
@@ -142,5 +143,14 @@ def __getattr__(key: str):
         from .wrappers import impl_preview
 
         return impl_preview
+    
+    # elif key == "VtkCanvas":
+    #     warnings.warn(
+    #         "Class `VtkCanvas` is deprecated. Use `VedoCanvas` instead.",
+    #         DeprecationWarning,
+    #         stacklevel=2,
+    #     )
+    #     from .ext.vtk import VedoCanvas
+    #     return VedoCanvas
 
     raise AttributeError(f"module {__name__!r} has no attribute {key!r}")

--- a/magicclass/ext/vtk/__init__.py
+++ b/magicclass/ext/vtk/__init__.py
@@ -1,5 +1,4 @@
 """
-VTK (Visualization Toolkit) support in a magicgui/magic-class way.
 This extension submodule depends on ``vedo``.
 
 .. code-block:: shell
@@ -8,6 +7,6 @@ This extension submodule depends on ``vedo``.
 
 """
 
-from .widgets import VtkCanvas
+from .widgets import VedoCanvas
 
-__all__ = ["VtkCanvas"]
+__all__ = ["VedoCanvas"]

--- a/magicclass/ext/vtk/__init__.py
+++ b/magicclass/ext/vtk/__init__.py
@@ -7,6 +7,6 @@ This extension submodule depends on ``vedo``.
 
 """
 
-from .widgets import VedoCanvas
+from .widgets import VedoCanvas, VtkCanvas
 
-__all__ = ["VedoCanvas"]
+__all__ = ["VedoCanvas", "VtkCanvas"]

--- a/magicclass/ext/vtk/const.py
+++ b/magicclass/ext/vtk/const.py
@@ -15,8 +15,7 @@ class StringEnum(Enum):
 
 
 class Rendering(StringEnum):
-    """Volume rendering mode suppored in vtk."""
-
+    """Volume rendering mode supported in vedo."""
     composite = 0
     mip = 1
     minip = 2

--- a/magicclass/ext/vtk/volume.py
+++ b/magicclass/ext/vtk/volume.py
@@ -6,7 +6,7 @@ from vedo.utils import numpy2vtk
 import numpy as np
 from magicgui.widgets import FloatSlider
 
-from .components import VtkComponent
+from .components import VedoComponent
 from .const import Mode, Rendering
 
 from magicclass.fields import vfield
@@ -35,7 +35,7 @@ def split_rgba(col: str | Sequence[float]) -> tuple[str | Sequence[float], float
     return [int(c * 255) for c in rgb], alpha * 255
 
 
-class Volume(VtkComponent, base=vedo.Volume):
+class Volume(VedoComponent, base=vedo.Volume):
     _obj: vedo.Volume
 
     def __init__(self, data, _parent):

--- a/magicclass/ext/vtk/widgets.py
+++ b/magicclass/ext/vtk/widgets.py
@@ -172,3 +172,12 @@ class VedoCanvas(FreeWidget):
             current_axes.EnabledOff()
         self.vedo_canvas._plt.axes_instances = [None]
         self.vedo_canvas._plt.show(axes=a)
+
+class VtkCanvas(VedoCanvas):
+    """
+    Deprecated. Use `VedoCanvas` instead.
+    """
+    def __init__(self):
+        """Deprecated. Use `VedoCanvas` instead."""
+        print("'VtkCanvas' is deprecated. Use 'VedoCanvas' instead.")
+        super().__init__()


### PR DESCRIPTION
This PR updates the existing class to support vedo 3d renderings, also adds an example of usage.

<img width="431" alt="Screenshot 2024-02-09 at 16 56 17" src="https://github.com/hanjinliu/magic-class/assets/32848391/ac805070-78a1-4eac-b5d4-c08dd88b4b14">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `VedoViewerUI` class for 3D visualization with points, axes, and a histogram.
- **Refactor**
	- Updated code to use `numpy` and `medfilt` for data filtering in `use_click.py`.
	- Renamed `self._filtrated` to `self._filtered` across relevant files.
	- Transitioned from VTK to Vedo for 3D components, affecting class names, type annotations, and method implementations in multiple files.
- **Documentation**
	- Updated documentation to reflect changes from VTK to Vedo in volume rendering modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->