### PR TITLE
Fix access violations using Qt6

### DIFF
--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -63,7 +63,7 @@ from ._macro_utils import (
     inject_silencer,
     inject_validator_only,
     value_widget_callback,
-    nested_function_gui_callback,
+    MagicGuiPostRunCallback,
 )
 from ._icon import get_icon
 from ._gui_modes import PopUpMode, ErrorMode
@@ -1292,8 +1292,7 @@ def normalize_insertion(parent: BaseGui, obj: Callable | Widget | AbstractAction
         # Sometimes users want to dynamically add new functions to GUI.
         if isinstance(obj, FunctionGui):
             if obj.parent is None:
-                f = nested_function_gui_callback(parent, obj)
-                obj.called.connect(f)
+                MagicGuiPostRunCallback.install(parent, obj)
             _obj = obj
         else:
             obj = convert_function(obj, is_method=False).__get__(parent)
@@ -1451,8 +1450,10 @@ def _implement_confirmation(
 
 def _empty_func(name: str) -> Callable[[Any], None]:
     """Create a named function that does nothing."""
+
     def f(x):
         pass
+
     f.__name__ = name
     return f
 

--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -1451,7 +1451,8 @@ def _implement_confirmation(
 
 def _empty_func(name: str) -> Callable[[Any], None]:
     """Create a named function that does nothing."""
-    f = lambda x: None
+    def f(x):
+        pass
     f.__name__ = name
     return f
 

--- a/magicclass/_gui/_icon.py
+++ b/magicclass/_gui/_icon.py
@@ -103,7 +103,7 @@ class IconifyIcon(_IconBase):
         if isinstance(dst.native, QWidget):
             palette = dst.native.palette()
         elif isinstance(dst.native, QAction):
-            if menu := dst.native.parentWidget():
+            if menu := dst.native.parent():
                 palette = menu.palette()
             else:
                 palette = None

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -13,6 +13,7 @@ from magicgui.widgets import (
     Image,
     Table,
     Widget,
+    EmptyWidget,
 )
 from magicgui.widgets.bases import (
     ButtonWidget,
@@ -193,8 +194,8 @@ class ClassGuiBase(BaseGui):
                                     alignment=Qt.AlignmentFlag.AlignTop,
                                 )
                                 self._toolbar.setContentsMargins(0, 0, 0, 0)
-                                if not isinstance(self, _USE_OUTER_LAYOUT):
-                                    n_insert += 1
+                                # if not isinstance(self, _USE_OUTER_LAYOUT):
+                                #     n_insert += 1
 
                     widget.native.setParent(self._toolbar, widget.native.windowFlags())
                     self._toolbar.addToolBar(
@@ -304,8 +305,9 @@ class ClassGuiBase(BaseGui):
         if key < 0:
             key += len(self)
         self._list.insert(key, widget)
-        if not remove_label:
-            self._widget._mgui_insert_widget(key, _widget)
+        if remove_label:
+            _widget = EmptyWidget(visible=False)
+        self._widget._mgui_insert_widget(key, _widget)
 
         # NOTE: Function GUI is invisible by some reason...
         # See https://github.com/hanjinliu/magic-class/issues/53

--- a/magicclass/_gui/class_gui.py
+++ b/magicclass/_gui/class_gui.py
@@ -141,7 +141,7 @@ class ClassGuiBase(BaseGui):
                     # Add menubar to container
                     if self._menubar is None:
                         # if widget has no menubar, a new one should be created.
-                        self._menubar = QMenuBar(parent=self.native)
+                        self._menubar = QMenuBar()
                         if issubclass(self.__class__, MainWindow):
                             self.native: QMainWindow
                             self.native.setMenuBar(self._menubar)
@@ -193,7 +193,8 @@ class ClassGuiBase(BaseGui):
                                     alignment=Qt.AlignmentFlag.AlignTop,
                                 )
                                 self._toolbar.setContentsMargins(0, 0, 0, 0)
-                                n_insert += 1
+                                if not isinstance(self, _USE_OUTER_LAYOUT):
+                                    n_insert += 1
 
                     widget.native.setParent(self._toolbar, widget.native.windowFlags())
                     self._toolbar.addToolBar(
@@ -303,7 +304,8 @@ class ClassGuiBase(BaseGui):
         if key < 0:
             key += len(self)
         self._list.insert(key, widget)
-        self._widget._mgui_insert_widget(key, _widget)
+        if not remove_label:
+            self._widget._mgui_insert_widget(key, _widget)
 
         # NOTE: Function GUI is invisible by some reason...
         # See https://github.com/hanjinliu/magic-class/issues/53
@@ -605,35 +607,35 @@ def make_gui(
 
 # fmt: off
 @make_gui(Container)
-class ClassGui: pass
+class ClassGui: pass  # noqa: E701
 @make_gui(SplitterContainer)
-class SplitClassGui: pass
+class SplitClassGui: pass  # noqa: E701
 @make_gui(ScrollableContainer)
-class ScrollableClassGui: pass
+class ScrollableClassGui: pass  # noqa: E701
 @make_gui(DraggableContainer)
-class DraggableClassGui: pass
+class DraggableClassGui: pass  # noqa: E701
 @make_gui(CollapsibleContainer)
-class CollapsibleClassGui: pass
+class CollapsibleClassGui: pass  # noqa: E701
 @make_gui(HCollapsibleContainer)
-class HCollapsibleClassGui: pass
+class HCollapsibleClassGui: pass  # noqa: E701
 @make_gui(ButtonContainer)
-class ButtonClassGui: pass
+class ButtonClassGui: pass  # noqa: E701
 @make_gui(ToolBoxContainer, no_margin=False)
-class ToolBoxClassGui: pass
+class ToolBoxClassGui: pass  # noqa: E701
 @make_gui(TabbedContainer, no_margin=False)
-class TabbedClassGui: pass
+class TabbedClassGui: pass  # noqa: E701
 @make_gui(StackedContainer, no_margin=False)
-class StackedClassGui: pass
+class StackedClassGui: pass  # noqa: E701
 @make_gui(ListContainer, no_margin=False)
-class ListClassGui: pass
+class ListClassGui: pass  # noqa: E701
 @make_gui(SubWindowsContainer, no_margin=False)
-class SubWindowsClassGui: pass
+class SubWindowsClassGui: pass  # noqa: E701
 @make_gui(GroupBoxContainer, no_margin=False)
-class GroupBoxClassGui: pass
+class GroupBoxClassGui: pass  # noqa: E701
 @make_gui(FrameContainer, no_margin=False)
-class FrameClassGui: pass
+class FrameClassGui: pass  # noqa: E701
 @make_gui(ResizableContainer, no_margin=False)
-class ResizableClassGui: pass
+class ResizableClassGui: pass  # noqa: E701
 @make_gui(MainWindow)
-class MainWindowClassGui: pass
+class MainWindowClassGui: pass  # noqa: E701
 # fmt: on

--- a/magicclass/_gui/menu_gui.py
+++ b/magicclass/_gui/menu_gui.py
@@ -194,8 +194,9 @@ class MenuGuiBase(ContainerLikeGui):
                 if self.labels:
                     if not isinstance(_obj.widget, _hide_labels) and not remove_label:
                         _obj_labeled = _LabeledWidgetAction.from_action(_obj)
-                _obj_labeled.parent = self
-                insert_action_like(self.native, key, _obj_labeled.native)
+                if not remove_label:
+                    _obj_labeled.parent = self
+                    insert_action_like(self.native, key, _obj_labeled.native)
 
             self._list.insert(key, _obj)
         else:

--- a/magicclass/_gui/toolbar.py
+++ b/magicclass/_gui/toolbar.py
@@ -259,8 +259,9 @@ class ToolBarGui(ContainerLikeGui):
                 if self.labels:
                     if not isinstance(_obj.widget, _hide_labels) and not remove_label:
                         _obj_labeled = _LabeledWidgetAction.from_action(_obj)
-                _obj_labeled.parent = self
-                insert_action_like(self.native, key, _obj_labeled.native)
+                if not remove_label:
+                    _obj_labeled.parent = self
+                    insert_action_like(self.native, key, _obj_labeled.native)
             self._list.insert(key, _obj)
         else:
             raise TypeError(f"{type(_obj)} is not supported.")

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -311,7 +311,7 @@ class MagicField(_FieldObject, Generic[_W]):
         if obj_id in self._guis.keys():
             action = self._guis[obj_id]
         else:
-            if type(self.value) is bool or self.annotation is bool:
+            if type(self.value) is bool or self.annotation is bool:  # noqa: E721
                 # we should not use "isinstance" or "issubclass" because subclass
                 # may be mapped to different widget by users.
                 value = False if self.value is Undefined else self.value

--- a/magicclass/utils/qthreading/thread_worker.py
+++ b/magicclass/utils/qthreading/thread_worker.py
@@ -69,7 +69,8 @@ class AsyncMethod(Protocol[_P, _R]):
 if TYPE_CHECKING:
     _async_method: Callable[[Callable[_P, _R]], AsyncMethod[_P, _R]]
 else:
-    _async_method = lambda f: f
+    def _async_method(f):
+        return f
 
 
 def _silent(*args, **kwargs):
@@ -82,7 +83,7 @@ class thread_worker(Callable, Generic[_P, _R]):
     _DEFAULT_PROGRESS_BAR = DefaultProgressBar
     _DEFAULT_TOTAL = 0
     _WINDOW_FLAG = Qt.WindowType.WindowTitleHint | Qt.WindowType.WindowMinimizeButtonHint | Qt.WindowType.Window  # fmt: skip
-    _BLOCKING_SOURCES = []
+    _BLOCKING_SOURCES: list[None] = []
 
     def __init__(
         self,

--- a/magicclass/widgets/containers.py
+++ b/magicclass/widgets/containers.py
@@ -178,7 +178,7 @@ class _Stack(ContainerBase):
 class _ScrollableContainer(ContainerBase):
     def __init__(self, layout="vertical", scrollable: bool = False, **kwargs):
         QBaseWidget.__init__(self, QtW.QWidget)
-        self._scroll_area = QtW.QScrollArea(self._qwidget)
+        self._scroll_area = QtW.QScrollArea()
         if layout == "horizontal":
             self._layout: QtW.QLayout = QtW.QHBoxLayout()
             self._layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -188,13 +188,14 @@ class _ScrollableContainer(ContainerBase):
 
         self._scroll_area.setWidgetResizable(True)
         self._scroll_area.setContentsMargins(0, 0, 0, 0)
-        self._inner_qwidget = QtW.QWidget(self._scroll_area)
+        self._inner_qwidget = QtW.QWidget()
         self._inner_qwidget.setLayout(self._layout)
         self._scroll_area.setWidget(self._inner_qwidget)
 
-        self._qwidget.setLayout(QtW.QVBoxLayout())
-        self._qwidget.layout().addWidget(self._scroll_area)
-        self._qwidget.layout().setContentsMargins(0, 0, 0, 0)
+        _layout = QtW.QVBoxLayout()
+        _layout.addWidget(self._scroll_area)
+        _layout.setContentsMargins(0, 0, 0, 0)
+        self._qwidget.setLayout(_layout)
 
     def _policy(self, value):
         if value:

--- a/magicclass/wrappers/_preview.py
+++ b/magicclass/wrappers/_preview.py
@@ -131,7 +131,8 @@ def get_arg_filter(
         if prev_params.keys() != tgt_params.keys():
             raise TypeError(f"Arguments mismatch between {prev_sig!r} and {tgt_sig!r}.")
         # If argument names are identical, input arguments don't have to be filtered.
-        _filter = lambda a: a
+        def _filter(a):
+            return a
 
     elif less > 0:
         idx: list[int] = []
@@ -140,7 +141,8 @@ def get_arg_filter(
                 idx.append(i)
         # If argument names are not identical, input arguments have to be filtered so
         # that arguments match the inputs.
-        _filter = lambda _args: (a for i, a in enumerate(_args) if i in idx)
+        def _filter(_args):
+            return tuple(a for i, a in enumerate(_args) if i in idx)
 
     else:
         raise TypeError(

--- a/tests/test_widget_types.py
+++ b/tests/test_widget_types.py
@@ -32,8 +32,6 @@ def _make_class(t: WidgetType):
 
 @pytest.mark.parametrize("wtype", WidgetType._member_names_)
 def test_all_works(wtype):
-    if QT6 and wtype in ("scrollable", "draggable"):
-        pytest.skip("QScrollArea crashes in QT6. Skip for now.")
     ui = _make_class(wtype)()
     ui.show(run=False)
     ui[0]

--- a/tests/test_wraps.py
+++ b/tests/test_wraps.py
@@ -4,8 +4,6 @@ from magicclass import (
 )
 from magicclass.types import Bound
 from unittest.mock import MagicMock
-import pytest
-from qtpy import QT6
 
 def test_single_wraps():
     @magicclass
@@ -108,8 +106,6 @@ def test_field_wraps():
     assert ui.new_attr == 0
 
 def test_wraps_no_predefinition():
-    if QT6:
-        pytest.skip("insertWidget crashes in QT6. Skip for now.")
     @magicclass
     class A:
         a = vfield(int)
@@ -167,8 +163,6 @@ def test_wraps_no_predefinition():
     ui.B.E["any_func"].changed()
 
 def test_wrapped_field():
-    if QT6:
-        pytest.skip("insertWidget crashes in QT6. Skip for now.")
     @magicclass
     class A:
         @magicclass
@@ -195,8 +189,6 @@ def test_wrapped_field():
 
 
 def test_wrapped_vfield():
-    if QT6:
-        pytest.skip("insertWidget crashes in QT6. Skip for now.")
     @magicclass
     class A:
         @magicclass


### PR DESCRIPTION
Fixes #136 
This PR also solved all the `pytest.skip` for Qt6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `MagicGuiPostRunCallback` for enhanced callback handling.
- **Bug Fixes**
	- Fixed logical condition for boolean value handling in widgets.
	- Corrected parent widget checking for icon palette retrieval.
	- Ensured proper widget display within scrollable containers.
- **Refactor**
	- Updated various methods and classes for improved code clarity and efficiency.
	- Transitioned from lambda to explicit `def` functions in certain areas for better readability.
- **Tests**
	- Streamlined test code by removing unnecessary dependencies and conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->