### PR TITLE
Fix using Union in field

### DIFF
--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -1167,8 +1167,6 @@ def _get_field(
             if len(_args) == 2 and None in _args:
                 tp = _args[0] if _args[0] is not None else _args[1]
                 kwargs.update(annotation=tp)
-            else:
-                raise ValueError(f"Union type must be `T | None`, got {obj}.")
         if _is_magicclass(obj):
             if widget_type is not None:
                 raise ValueError("Cannot specify Widget type twice.")

--- a/magicclass/fields/_fields.py
+++ b/magicclass/fields/_fields.py
@@ -7,10 +7,11 @@ from typing import (
     Callable,
     Sequence,
     TypeVar,
+    Union,
     overload,
     Generic,
 )
-from typing_extensions import Literal
+from typing_extensions import Literal, get_args, get_origin
 import threading
 from timeit import default_timer
 from functools import wraps
@@ -1161,6 +1162,13 @@ def _get_field(
             tp, widget_option = split_annotated_type(obj)
             kwargs.update(annotation=tp)
             options.update(**widget_option)
+        elif get_origin(obj) is Union:
+            _args = get_args(obj)
+            if len(_args) == 2 and None in _args:
+                tp = _args[0] if _args[0] is not None else _args[1]
+                kwargs.update(annotation=tp)
+            else:
+                raise ValueError(f"Union type must be `T | None`, got {obj}.")
         if _is_magicclass(obj):
             if widget_type is not None:
                 raise ValueError("Cannot specify Widget type twice.")

--- a/magicclass/utils/_functions.py
+++ b/magicclass/utils/_functions.py
@@ -14,8 +14,14 @@ try:
 except ImportError:
     from typing_extensions import _BaseGenericAlias
 
-_UnionType = type(Union[int, str])
-_type_like = (type, _UnionType, _BaseGenericAlias)
+_type_like = (type, type(Union[int, str]), _BaseGenericAlias)
+
+try:
+    from types import UnionType
+
+    _type_like += (UnionType,)
+except ImportError:
+    pass
 
 try:
     from types import GenericAlias

--- a/magicclass/utils/_functions.py
+++ b/magicclass/utils/_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from functools import cached_property
 import inspect
-from types import MethodType
+from types import MethodType, UnionType
 from typing import Any, TYPE_CHECKING, Callable, Iterable
 import warnings
 from docstring_parser import parse
@@ -14,7 +14,7 @@ try:
 except ImportError:
     from typing_extensions import _BaseGenericAlias
 
-_type_like = (type, _BaseGenericAlias)
+_type_like = (type, UnionType, _BaseGenericAlias)
 
 try:
     from types import GenericAlias

--- a/magicclass/utils/_functions.py
+++ b/magicclass/utils/_functions.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from functools import cached_property
 import inspect
-from types import MethodType, UnionType
-from typing import Any, TYPE_CHECKING, Callable, Iterable
+from types import MethodType
+from typing import Any, TYPE_CHECKING, Callable, Iterable, Union
 import warnings
 from docstring_parser import parse
 
@@ -14,7 +14,8 @@ try:
 except ImportError:
     from typing_extensions import _BaseGenericAlias
 
-_type_like = (type, UnionType, _BaseGenericAlias)
+_UnionType = type(Union[int, str])
+_type_like = (type, _UnionType, _BaseGenericAlias)
 
 try:
     from types import GenericAlias

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 from typing_extensions import Annotated
 from magicclass import (
     magicclass,
@@ -825,6 +826,23 @@ def test_using_same_class():
     ui.laser_red["apply"].changed()
 
 def test_union():
+    class E(Enum):
+        a = 1
+        b = 2
+
+    @magicclass
+    class A:
+        x = field(Union[E, None])
+        y = vfield(Union[E, None]).with_options(value=E.a)
+
+    ui = A()
+    assert ui.x.value is None
+    assert ui.y is E.a
+    assert list(ui.x.choices) == [None, E.a, E.b]
+    assert list(ui["y"].choices) == [None, E.a, E.b]
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10+")
+def test_union_type():
     class E(Enum):
         a = 1
         b = 2

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing_extensions import Annotated
 from magicclass import (
     magicclass,
@@ -66,7 +67,7 @@ def test_field_types():
     assert b.a_int.value == 0
     assert b.a_float.value == 0.0
     assert b.a_str.value == "0"
-    assert b.a_bool.value == False
+    assert b.a_bool.value is False
 
     b.a_int.value = 1
     len0 = len(b.macro)
@@ -113,7 +114,7 @@ def test_vfield_types():
     assert b.a_int == 0
     assert b.a_float == 0.0
     assert b.a_str == "0"
-    assert b.a_bool == False
+    assert b.a_bool is False
 
     b.a_int = 1
     len0 = len(b.macro)
@@ -822,3 +823,19 @@ def test_using_same_class():
     assert ui.laser_red.bar == 0
     ui.laser_green["apply"].changed()
     ui.laser_red["apply"].changed()
+
+def test_union():
+    class E(Enum):
+        a = 1
+        b = 2
+
+    @magicclass
+    class A:
+        x = field(E | None)
+        y = vfield(E | None).with_options(value=E.a)
+
+    ui = A()
+    assert ui.x.value is None
+    assert ui.y is E.a
+    assert list(ui.x.choices) == [None, E.a, E.b]
+    assert list(ui["y"].choices) == [None, E.a, E.b]


### PR DESCRIPTION
`T | None` was not interpreted as nullable widget. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced type handling to support `Union` types, improving flexibility in field definitions.
- **Refactor**
	- Expanded internal type considerations to include `UnionType`, enhancing the framework's robustness.
- **Tests**
	- Improved boolean assertions in tests for clarity and correctness.
	- Added tests for new union field functionality, ensuring reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->