### PR TITLE
Support `super()` in the Container-like methods

### DIFF
--- a/magicclass/__init__.py
+++ b/magicclass/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.10"
+__version__ = "0.7.11"
 
 from .core import (
     magicclass,

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -302,3 +302,27 @@ def test_contextmenu_injection():
     ui = A()
     ui.X.g()
     assert str(ui.macro[-1]) == "ui.X.g()"
+
+def test_super():
+    @magicclass
+    class A(MagicTemplate):
+        def __init__(self):
+            self._hist = []
+
+        def f(self):
+            pass
+
+        def show(self):
+            self._hist.append("show")
+            super().show()
+
+        def __getitem__(self, key):
+            self._hist.append("getitem")
+            return super().__getitem__(key)
+
+    ui = A()
+    ui.show()
+    ui.close()
+    ui[0]
+    assert ui._hist == ["show", "getitem"]
+    assert len(ui.macro) == 1


### PR DESCRIPTION
Magic classes could not override the Container methods such as `reset_choices`, but sometimes it is needed.
This PR allows that kind of usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a method to dynamically locate a superclass within `MagicTemplate` methods, improving method delegation.

- **Tests**
  - Introduced a new test to verify superclass method calls and sequence operations.

- **Chores**
  - Updated the version number from "0.7.10" to "0.7.11".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->