### PR TITLE
Use magicgui Separator object

### DIFF
--- a/magicclass/_gui/_base.py
+++ b/magicclass/_gui/_base.py
@@ -35,10 +35,8 @@ from magicgui.widgets import (
     Label,
 )
 from magicgui.application import use_app
-from magicgui.widgets.bases import (
-    ButtonWidget,
-    ValueWidget,
-)
+from magicgui.widgets.bases import ButtonWidget, ValueWidget
+from magicgui import types as _mgui_types
 from macrokit import Symbol
 
 from magicclass._gui.keybinding import as_shortcut
@@ -700,7 +698,7 @@ class MagicTemplate(
             )
             widget = attr
 
-        elif isinstance(attr, str) and attr == "separator":
+        elif _is_separator(attr):
             widget = Separator()
         else:
             # convert class method into instance method
@@ -1436,6 +1434,17 @@ def _define_popup(self: BaseGui, obj, widget: Clickable):
     else:
         raise RuntimeError(popup_mode)
     return _prep
+
+
+_void = object()
+
+
+def _is_separator(attr) -> bool:
+    if isinstance(attr, str) and attr == "separator":
+        return True
+    if attr is getattr(_mgui_types, "Separator", _void):
+        return True
+    return False
 
 
 def _implement_confirmation(

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -90,6 +90,7 @@ def test_toolbar():
 
 def test_separator():
     from magicclass.widgets import Separator
+    from magicgui.types import Separator as mgui_Separator
     @magicclass
     class A:
         @magicmenu
@@ -99,10 +100,12 @@ def test_separator():
             i = field(int)
             sep1 = "separator"
             def m2(self, path: Path): ...
+            sep2 = mgui_Separator
 
     ui = A()
     assert type(ui.Menu[1].widget) is Separator
     assert type(ui.Menu[3].widget) is Separator
+    assert type(ui.Menu[5].widget) is Separator
 
     @magicclass
     class A:
@@ -113,10 +116,12 @@ def test_separator():
             i = field(int)
             sep1 = "separator"
             def m2(self, path: Path): ...
+            sep2 = mgui_Separator
 
     ui = A()
     assert type(ui.Menu[1].widget) is Separator
     assert type(ui.Menu[3].widget) is Separator
+    assert type(ui.Menu[5].widget) is Separator
 
 
 def test_tooltip():


### PR DESCRIPTION
As magicgui natively supported Separator object, we can also use it for adding separators to magicclass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal imports and structure for better code maintainability.
- **Tests**
	- Updated test cases to enhance accuracy and reliability of widget type assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->